### PR TITLE
Refactor/#17: 이벤트 발행 outbox로 전환

### DIFF
--- a/src/main/java/com/project/yogerOrder/global/config/GlobalConfig.java
+++ b/src/main/java/com/project/yogerOrder/global/config/GlobalConfig.java
@@ -1,6 +1,7 @@
 package com.project.yogerOrder.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class GlobalConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.registerModule(new JavaTimeModule());
     }
 }

--- a/src/main/java/com/project/yogerOrder/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/yogerOrder/global/config/KafkaConfig.java
@@ -13,21 +13,16 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
-import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 
@@ -54,35 +49,6 @@ public class KafkaConfig {
             config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, configValue.bootstrapServers);
 
             return new KafkaAdmin(config);
-        }
-
-    }
-
-    @Configuration
-    @RequiredArgsConstructor
-    public static class KafkaProducerConfig {
-
-        private final KafkaProducerConfigValue configValue;
-
-        @ConfigurationProperties(prefix = "kafka.producer")
-        public record KafkaProducerConfigValue(@NotBlank String bootstrapServers, @NotNull Boolean enableIdempotence,
-                                               @NotNull String transactionIdPrefix) {
-        }
-
-        private HashMap<String, Object> producerConfig() {
-            HashMap<String, Object> config = new HashMap<>();
-            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, configValue.bootstrapServers);
-            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-            config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, configValue.enableIdempotence);
-            config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, configValue.transactionIdPrefix);
-
-            return config;
-        }
-
-        @Bean
-        public KafkaTemplate<String, Object> OrderCreatedEventKafkaTemplate() {
-            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(producerConfig()));
         }
 
     }

--- a/src/main/java/com/project/yogerOrder/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/yogerOrder/global/config/KafkaConfig.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 public class KafkaConfig {
 
     public static final String ORDER_GROUP = "order-group";
+    public static final String PAYMENT_GROUP = "payment-group";
 
     @Configuration
     @RequiredArgsConstructor

--- a/src/main/java/com/project/yogerOrder/global/util/outbox/entity/OutboxEntity.java
+++ b/src/main/java/com/project/yogerOrder/global/util/outbox/entity/OutboxEntity.java
@@ -1,0 +1,35 @@
+package com.project.yogerOrder.global.util.outbox.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class OutboxEntity {
+
+    @Id
+    @NotBlank
+    protected String eventId;
+
+    @NotBlank
+    protected String eventType;
+
+    @NotBlank
+    private String payload;
+
+    @CreatedDate
+    private LocalDateTime occurrenceTime;
+
+
+    protected OutboxEntity(String eventType, String payload) {
+        this.eventId = UUID.randomUUID().toString();
+        this.eventType = eventType;
+        this.payload = payload;
+    }
+}

--- a/src/main/java/com/project/yogerOrder/order/config/OrderTopic.java
+++ b/src/main/java/com/project/yogerOrder/order/config/OrderTopic.java
@@ -10,17 +10,11 @@ public class OrderTopic {
 
 
     public static String getTopicByEvent(OrderEventType orderEventType) {
-        switch (orderEventType) {
-            case CREATED:
-                return CREATED;
-            case COMPLETED:
-                return COMPLETED;
-            case CANCELED:
-                return CANCELED;
-            case ERRORED:
-                return ERRORED;
-            default:
-                throw new RuntimeException("Invalid event type");
-        }
+        return switch (orderEventType) {
+            case CREATED -> CREATED;
+            case COMPLETED -> COMPLETED;
+            case CANCELED -> CANCELED;
+            case ERRORED -> ERRORED;
+        };
     }
 }

--- a/src/main/java/com/project/yogerOrder/order/config/OrderTopic.java
+++ b/src/main/java/com/project/yogerOrder/order/config/OrderTopic.java
@@ -1,8 +1,26 @@
 package com.project.yogerOrder.order.config;
 
+import com.project.yogerOrder.order.event.OrderEventType;
+
 public class OrderTopic {
     public static final String CREATED = "yoger.order.prd.created";
     public static final String COMPLETED = "yoger.order.prd.completed";
     public static final String CANCELED = "yoger.order.prd.canceled";
     public static final String ERRORED = "yoger.order.prd.errored";
+
+
+    public static String getTopicByEvent(OrderEventType orderEventType) {
+        switch (orderEventType) {
+            case CREATED:
+                return CREATED;
+            case COMPLETED:
+                return COMPLETED;
+            case CANCELED:
+                return CANCELED;
+            case ERRORED:
+                return ERRORED;
+            default:
+                throw new RuntimeException("Invalid event type");
+        }
+    }
 }

--- a/src/main/java/com/project/yogerOrder/order/event/OrderErroredEvent.java
+++ b/src/main/java/com/project/yogerOrder/order/event/OrderErroredEvent.java
@@ -17,7 +17,7 @@ public record OrderErroredEvent(@NotNull Long orderId, @NotBlank String eventId,
         return new OrderErroredEvent(
                 orderEntity.getId(),
                 UUID.randomUUID().toString(),
-                OrderEventType.ERROR,
+                OrderEventType.ERRORED,
                 new OrderErroredData(orderEntity.getBuyerId(), orderEntity.getProductId(), orderEntity.getQuantity()),
                 LocalDateTime.now()
         );

--- a/src/main/java/com/project/yogerOrder/order/event/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/OrderEventProducer.java
@@ -13,32 +13,32 @@ public class OrderEventProducer {
     private final OrderOutboxService orderOutboxService;
 
 
-    public void sendEventByState(OrderEntity orderEntity) {
-        if (orderEntity.getState() == OrderState.COMPLETED) {
-            sendOrderCompletedEvent(orderEntity);
-        } else if (orderEntity.getState() == OrderState.CREATED) {
-            sendOrderCreatedEvent(orderEntity);
-        } else if (orderEntity.getState() == OrderState.CANCELED) {
-            sendOrderCanceledEvent(orderEntity);
+    public void publishEventByState(OrderEntity orderEntity) {
+        if (orderEntity.getState() == OrderState.CREATED) {
+            publishOrderCreatedEvent(orderEntity);
+        } else if (orderEntity.getState() == OrderState.COMPLETED) {
+            publishOrderCompletedEvent(orderEntity);
+        }  else if (orderEntity.getState() == OrderState.CANCELED) {
+            publishOrderCanceledEvent(orderEntity);
         } else if (orderEntity.getState() == OrderState.ERROR) {
-            sendOrderCanceledEvent(orderEntity);
-            sendOrderErroredEvent(orderEntity);
+            publishOrderCanceledEvent(orderEntity);
+            publishOrderErroredEvent(orderEntity);
         }
     }
 
-    private void sendOrderCreatedEvent(OrderEntity orderEntity) {
+    private void publishOrderCreatedEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(OrderEventType.CREATED, OrderCreatedEvent.from(orderEntity));
     }
 
-    private void sendOrderCanceledEvent(OrderEntity orderEntity) {
-        orderOutboxService.saveOutbox(OrderEventType.CANCELED, OrderCanceledEvent.from(orderEntity));
-    }
-
-    private void sendOrderCompletedEvent(OrderEntity orderEntity) {
+    private void publishOrderCompletedEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(OrderEventType.COMPLETED, OrderCompletedEvent.from(orderEntity));
     }
 
-    private void sendOrderErroredEvent(OrderEntity orderEntity) {
+    private void publishOrderCanceledEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.CANCELED, OrderCanceledEvent.from(orderEntity));
+    }
+
+    private void publishOrderErroredEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(OrderEventType.ERRORED, OrderErroredEvent.from(orderEntity));
     }
 }

--- a/src/main/java/com/project/yogerOrder/order/event/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/OrderEventProducer.java
@@ -24,6 +24,8 @@ public class OrderEventProducer {
             publishOrderCanceledEvent(orderEntity);
             publishOrderErroredEvent(orderEntity);
         }
+
+        throw new IllegalArgumentException("Invalid Order State" + orderEntity.getState());
     }
 
     private void publishOrderCreatedEvent(OrderEntity orderEntity) {

--- a/src/main/java/com/project/yogerOrder/order/event/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/OrderEventProducer.java
@@ -1,34 +1,17 @@
 package com.project.yogerOrder.order.event;
 
-import com.project.yogerOrder.order.config.OrderTopic;
 import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.entity.OrderState;
+import com.project.yogerOrder.order.event.outbox.service.OrderOutboxService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class OrderEventProducer {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final OrderOutboxService orderOutboxService;
 
-
-    public void sendOrderCreatedEvent(OrderEntity orderEntity) {
-        kafkaTemplate.send(OrderTopic.CREATED, OrderCreatedEvent.from(orderEntity));
-    }
-
-    public void sendOrderCanceledEvent(OrderEntity orderEntity) {
-        kafkaTemplate.send(OrderTopic.CANCELED, OrderCanceledEvent.from(orderEntity));
-    }
-
-    public void sendOrderCompletedEvent(OrderEntity orderEntity) {
-        kafkaTemplate.send(OrderTopic.COMPLETED, OrderCompletedEvent.from(orderEntity));
-    }
-
-    public void sendOrderErroredEvent(OrderEntity orderEntity) {
-        kafkaTemplate.send(OrderTopic.ERRORED, OrderErroredEvent.from(orderEntity));
-    }
 
     public void sendEventByState(OrderEntity orderEntity) {
         if (orderEntity.getState() == OrderState.COMPLETED) {
@@ -41,5 +24,21 @@ public class OrderEventProducer {
             sendOrderCanceledEvent(orderEntity);
             sendOrderErroredEvent(orderEntity);
         }
+    }
+
+    private void sendOrderCreatedEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.CREATED, OrderCreatedEvent.from(orderEntity));
+    }
+
+    private void sendOrderCanceledEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.CANCELED, OrderCanceledEvent.from(orderEntity));
+    }
+
+    private void sendOrderCompletedEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.COMPLETED, OrderCompletedEvent.from(orderEntity));
+    }
+
+    private void sendOrderErroredEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.ERRORED, OrderErroredEvent.from(orderEntity));
     }
 }

--- a/src/main/java/com/project/yogerOrder/order/event/OrderEventType.java
+++ b/src/main/java/com/project/yogerOrder/order/event/OrderEventType.java
@@ -1,5 +1,5 @@
 package com.project.yogerOrder.order.event;
 
 public enum OrderEventType {
-    CREATED, COMPLETED, CANCELED, ERROR
+    CREATED, COMPLETED, CANCELED, ERRORED
 }

--- a/src/main/java/com/project/yogerOrder/order/event/outbox/entity/OrderOutboxEntity.java
+++ b/src/main/java/com/project/yogerOrder/order/event/outbox/entity/OrderOutboxEntity.java
@@ -1,0 +1,18 @@
+package com.project.yogerOrder.order.event.outbox.entity;
+
+import com.project.yogerOrder.global.util.outbox.entity.OutboxEntity;
+import com.project.yogerOrder.order.config.OrderTopic;
+import com.project.yogerOrder.order.event.OrderEventType;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class OrderOutboxEntity extends OutboxEntity {
+
+    public OrderOutboxEntity(OrderEventType eventType, String payload) {
+        super(OrderTopic.getTopicByEvent(eventType), payload);
+    }
+}

--- a/src/main/java/com/project/yogerOrder/order/event/outbox/repository/OrderOutboxRepository.java
+++ b/src/main/java/com/project/yogerOrder/order/event/outbox/repository/OrderOutboxRepository.java
@@ -1,0 +1,9 @@
+package com.project.yogerOrder.order.event.outbox.repository;
+
+import com.project.yogerOrder.order.event.outbox.entity.OrderOutboxEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderOutboxRepository extends JpaRepository<OrderOutboxEntity, String> {
+}

--- a/src/main/java/com/project/yogerOrder/order/event/outbox/service/OrderOutboxService.java
+++ b/src/main/java/com/project/yogerOrder/order/event/outbox/service/OrderOutboxService.java
@@ -1,0 +1,30 @@
+package com.project.yogerOrder.order.event.outbox.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.yogerOrder.order.event.OrderEventType;
+import com.project.yogerOrder.order.event.outbox.entity.OrderOutboxEntity;
+import com.project.yogerOrder.order.event.outbox.repository.OrderOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderOutboxService {
+
+    private final OrderOutboxRepository orderOutboxRepository;
+
+    private final ObjectMapper objectMapper;
+
+    public void saveOutbox(OrderEventType eventType, Object payload) {
+        try {
+            String stringPayload = objectMapper.writeValueAsString(payload);
+            orderOutboxRepository.save(new OrderOutboxEntity(eventType, stringPayload));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
@@ -17,6 +17,10 @@ public class OrderEventProducer {
     public void publishEventByState(OrderEntity orderEntity) {
         if (orderEntity.getState() == OrderState.CREATED) {
             publishOrderCreatedEvent(orderEntity);
+        } else if (orderEntity.getState() == OrderState.STOCK_CONFIRMED) {
+            // stock confirmed event ignored
+        } else if (orderEntity.getState() == OrderState.PAYMENT_COMPLETED) {
+            // payment completed event ignored
         } else if (orderEntity.getState() == OrderState.COMPLETED) {
             publishOrderCompletedEvent(orderEntity);
         }  else if (orderEntity.getState() == OrderState.CANCELED) {

--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
@@ -28,9 +28,9 @@ public class OrderEventProducer {
         } else if (orderEntity.getState() == OrderState.ERROR) {
             publishOrderCanceledEvent(orderEntity);
             publishOrderErroredEvent(orderEntity);
+        } else {
+            throw new IllegalArgumentException("Invalid Order State" + orderEntity.getState());
         }
-
-        throw new IllegalArgumentException("Invalid Order State" + orderEntity.getState());
     }
 
     private void publishOrderCreatedEvent(OrderEntity orderEntity) {

--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
@@ -1,7 +1,8 @@
-package com.project.yogerOrder.order.event;
+package com.project.yogerOrder.order.event.producer;
 
 import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.entity.OrderState;
+import com.project.yogerOrder.order.event.*;
 import com.project.yogerOrder.order.event.outbox.service.OrderOutboxService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/project/yogerOrder/order/service/OrderService.java
+++ b/src/main/java/com/project/yogerOrder/order/service/OrderService.java
@@ -39,7 +39,7 @@ public class OrderService {
         OrderEntity pendingOrder = OrderEntity.createPendingOrder(productId, orderRequestDTO.quantity(), userId);
         OrderEntity orderEntity = orderRepository.save(pendingOrder);
 
-        orderEventProducer.sendEventByState(orderEntity);
+        orderEventProducer.publishEventByState(orderEntity);
 
         return orderEntity.getId();
     }
@@ -83,7 +83,7 @@ public class OrderService {
         }
         orderRepository.save(orderEntity);
 
-        orderEventProducer.sendEventByState(orderEntity);
+        orderEventProducer.publishEventByState(orderEntity);
     }
 
     @Transactional
@@ -96,7 +96,7 @@ public class OrderService {
         }
         orderRepository.save(orderEntity);
 
-        orderEventProducer.sendEventByState(orderEntity);
+        orderEventProducer.publishEventByState(orderEntity);
     }
 
     @Transactional
@@ -109,7 +109,7 @@ public class OrderService {
         }
         orderRepository.save(orderEntity);
 
-        orderEventProducer.sendEventByState(orderEntity);
+        orderEventProducer.publishEventByState(orderEntity);
     }
 
     @Transactional
@@ -122,7 +122,7 @@ public class OrderService {
         }
         orderRepository.save(orderEntity);
 
-        orderEventProducer.sendEventByState(orderEntity);
+        orderEventProducer.publishEventByState(orderEntity);
     }
 
     @Transactional
@@ -134,7 +134,7 @@ public class OrderService {
         }
         orderRepository.save(orderEntity);
 
-        orderEventProducer.sendEventByState(orderEntity);
+        orderEventProducer.publishEventByState(orderEntity);
     }
 
 

--- a/src/main/java/com/project/yogerOrder/order/service/OrderService.java
+++ b/src/main/java/com/project/yogerOrder/order/service/OrderService.java
@@ -8,7 +8,7 @@ import com.project.yogerOrder.order.dto.response.OrderCountResponseDTOs;
 import com.project.yogerOrder.order.dto.response.OrderResponseDTOs;
 import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.entity.OrderState;
-import com.project.yogerOrder.order.event.OrderEventProducer;
+import com.project.yogerOrder.order.event.producer.OrderEventProducer;
 import com.project.yogerOrder.order.exception.OrderNotFoundException;
 import com.project.yogerOrder.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/project/yogerOrder/payment/config/PaymentTopic.java
+++ b/src/main/java/com/project/yogerOrder/payment/config/PaymentTopic.java
@@ -1,7 +1,22 @@
 package com.project.yogerOrder.payment.config;
 
+import com.project.yogerOrder.payment.event.PaymentEventType;
+
 public class PaymentTopic {
     public static final String COMPLETED = "yoger.payment.prd.completed";
     public static final String CANCELED = "yoger.payment.prd.canceled";
     public static final String ERRORED = "yoger.payment.prd.errored";
+
+    public static String getTopicByEvent(PaymentEventType paymentEventType) {
+        switch (paymentEventType) {
+            case COMPLETED:
+                return COMPLETED;
+            case CANCELED:
+                return CANCELED;
+            case ERRORED:
+                return ERRORED;
+            default:
+                throw new RuntimeException("Invalid event type");
+        }
+    }
 }

--- a/src/main/java/com/project/yogerOrder/payment/config/PaymentTopic.java
+++ b/src/main/java/com/project/yogerOrder/payment/config/PaymentTopic.java
@@ -8,15 +8,10 @@ public class PaymentTopic {
     public static final String ERRORED = "yoger.payment.prd.errored";
 
     public static String getTopicByEvent(PaymentEventType paymentEventType) {
-        switch (paymentEventType) {
-            case COMPLETED:
-                return COMPLETED;
-            case CANCELED:
-                return CANCELED;
-            case ERRORED:
-                return ERRORED;
-            default:
-                throw new RuntimeException("Invalid event type");
-        }
+        return switch (paymentEventType) {
+            case COMPLETED -> COMPLETED;
+            case CANCELED -> CANCELED;
+            case ERRORED -> ERRORED;
+        };
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/event/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/PaymentEventProducer.java
@@ -15,30 +15,30 @@ public class PaymentEventProducer {
 
     private final PaymentOutboxService paymentOutboxService;
 
-    public void sendEventByState(PaymentEntity paymentEntity) {
+    public void publishEventByState(PaymentEntity paymentEntity) {
         if (paymentEntity.getState() == PaymentState.TEMPORARY_PAID) {
             // temporary paid payment is ignored
         } else if (paymentEntity.getState() == PaymentState.PAID_END) {
-            sendPaymentCompletedEvent(paymentEntity);
+            publishPaymentCompletedEvent(paymentEntity);
         } else if (paymentEntity.getState() == PaymentState.CANCELED) {
-            sendPaymentCanceledEvent(paymentEntity);
+            publishPaymentCanceledEvent(paymentEntity);
         } else if (paymentEntity.getState() == PaymentState.ERROR) {
-            sendPaymentCanceledEvent(paymentEntity);
-            sendPaymentErroredEvent(paymentEntity);
+            publishPaymentCanceledEvent(paymentEntity);
+            publishPaymentErroredEvent(paymentEntity);
         }
 
         throw new IllegalArgumentException("Invalid payment state: " + paymentEntity.getState());
     }
 
-    private void sendPaymentCompletedEvent(PaymentEntity paymentEntity) {
+    private void publishPaymentCompletedEvent(PaymentEntity paymentEntity) {
         paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentCompletedEvent.from(paymentEntity));
     }
 
-    private void sendPaymentCanceledEvent(PaymentEntity paymentEntity) {
+    private void publishPaymentCanceledEvent(PaymentEntity paymentEntity) {
         paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentCanceledEvent.from(paymentEntity));
     }
 
-    private void sendPaymentErroredEvent(PaymentEntity paymentEntity) {
+    private void publishPaymentErroredEvent(PaymentEntity paymentEntity) {
         paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentErroredEvent.from(paymentEntity));
     }
 

--- a/src/main/java/com/project/yogerOrder/payment/event/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/PaymentEventProducer.java
@@ -1,11 +1,10 @@
 package com.project.yogerOrder.payment.event;
 
 
-import com.project.yogerOrder.payment.config.PaymentTopic;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
+import com.project.yogerOrder.payment.event.outbox.service.PaymentOutboxService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -13,7 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PaymentEventProducer {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final PaymentOutboxService paymentOutboxService;
 
     public void sendEventByState(PaymentEntity paymentEntity) {
         switch (paymentEntity.getState()) {
@@ -37,16 +36,15 @@ public class PaymentEventProducer {
     }
 
     private void sendPaymentCompletedEvent(PaymentEntity paymentEntity) {
-        kafkaTemplate.send(PaymentTopic.COMPLETED, PaymentCompletedEvent.from(paymentEntity));
+        paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentCompletedEvent.from(paymentEntity));
     }
 
     private void sendPaymentCanceledEvent(PaymentEntity paymentEntity) {
-        kafkaTemplate.send(PaymentTopic.CANCELED, PaymentCanceledEvent.from(paymentEntity));
+        paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentCanceledEvent.from(paymentEntity));
     }
 
     private void sendPaymentErroredEvent(PaymentEntity paymentEntity) {
-        kafkaTemplate.send(PaymentTopic.ERRORED, PaymentErroredEvent.from(paymentEntity));
+        paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentErroredEvent.from(paymentEntity));
     }
 
 }
-

--- a/src/main/java/com/project/yogerOrder/payment/event/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/PaymentEventProducer.java
@@ -2,6 +2,7 @@ package com.project.yogerOrder.payment.event;
 
 
 import com.project.yogerOrder.payment.entity.PaymentEntity;
+import com.project.yogerOrder.payment.entity.PaymentState;
 import com.project.yogerOrder.payment.event.outbox.service.PaymentOutboxService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,24 +16,18 @@ public class PaymentEventProducer {
     private final PaymentOutboxService paymentOutboxService;
 
     public void sendEventByState(PaymentEntity paymentEntity) {
-        switch (paymentEntity.getState()) {
-            case PAID_END:
-                sendPaymentCompletedEvent(paymentEntity);
-                break;
-            case TEMPORARY_PAID:
-                //sendPaymentCompletedEvent(paymentEntity);
-                log.info("Temporary paid payment is ignored: {}", paymentEntity);
-                break;
-            case CANCELED:
-                sendPaymentCanceledEvent(paymentEntity);
-                break;
-            case ERROR:
-                sendPaymentCanceledEvent(paymentEntity);
-                sendPaymentErroredEvent(paymentEntity);
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown payment state: " + paymentEntity.getState());
+        if (paymentEntity.getState() == PaymentState.TEMPORARY_PAID) {
+            // temporary paid payment is ignored
+        } else if (paymentEntity.getState() == PaymentState.PAID_END) {
+            sendPaymentCompletedEvent(paymentEntity);
+        } else if (paymentEntity.getState() == PaymentState.CANCELED) {
+            sendPaymentCanceledEvent(paymentEntity);
+        } else if (paymentEntity.getState() == PaymentState.ERROR) {
+            sendPaymentCanceledEvent(paymentEntity);
+            sendPaymentErroredEvent(paymentEntity);
         }
+
+        throw new IllegalArgumentException("Invalid payment state: " + paymentEntity.getState());
     }
 
     private void sendPaymentCompletedEvent(PaymentEntity paymentEntity) {

--- a/src/main/java/com/project/yogerOrder/payment/event/PaymentEventType.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/PaymentEventType.java
@@ -1,5 +1,5 @@
 package com.project.yogerOrder.payment.event;
 
 public enum PaymentEventType {
-    COMPLETED, CANCELED
+    COMPLETED, CANCELED, ERRORED
 }

--- a/src/main/java/com/project/yogerOrder/payment/event/consumer/PaymentEventConsumer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/consumer/PaymentEventConsumer.java
@@ -1,5 +1,6 @@
 package com.project.yogerOrder.payment.event.consumer;
 
+import com.project.yogerOrder.global.config.KafkaConfig;
 import com.project.yogerOrder.order.config.OrderTopic;
 import com.project.yogerOrder.order.event.OrderCanceledEvent;
 import com.project.yogerOrder.payment.service.PaymentService;
@@ -14,8 +15,8 @@ public class PaymentEventConsumer {
 
     private final PaymentService paymentService;
 
-    @KafkaListener(topics = OrderTopic.CANCELED, groupId = "payment-group",
-            containerFactory = "orderCanceledFactory")
+    @KafkaListener(topics = OrderTopic.CANCELED, groupId = KafkaConfig.PAYMENT_GROUP,
+            containerFactory = KafkaConfig.KafkaConsumerConfig.ORDER_CANCELED_FACTORY)
     public void orderCanceled(OrderCanceledEvent event, Acknowledgment acknowledgment) {
         paymentService.orderCanceled(event.orderId());
 

--- a/src/main/java/com/project/yogerOrder/payment/event/outbox/entity/PaymentOutboxEntity.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/outbox/entity/PaymentOutboxEntity.java
@@ -1,0 +1,16 @@
+package com.project.yogerOrder.payment.event.outbox.entity;
+
+import com.project.yogerOrder.global.util.outbox.entity.OutboxEntity;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class PaymentOutboxEntity extends OutboxEntity {
+
+    public PaymentOutboxEntity(String eventType, String payload) {
+        super(eventType, payload);
+    }
+}

--- a/src/main/java/com/project/yogerOrder/payment/event/outbox/entity/PaymentOutboxEntity.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/outbox/entity/PaymentOutboxEntity.java
@@ -1,6 +1,8 @@
 package com.project.yogerOrder.payment.event.outbox.entity;
 
 import com.project.yogerOrder.global.util.outbox.entity.OutboxEntity;
+import com.project.yogerOrder.payment.config.PaymentTopic;
+import com.project.yogerOrder.payment.event.PaymentEventType;
 import jakarta.persistence.Entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PaymentOutboxEntity extends OutboxEntity {
 
-    public PaymentOutboxEntity(String eventType, String payload) {
-        super(eventType, payload);
+    public PaymentOutboxEntity(PaymentEventType eventType, String payload) {
+        super(PaymentTopic.getTopicByEvent(eventType), payload);
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/event/outbox/repository/PaymentOutboxRepository.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/outbox/repository/PaymentOutboxRepository.java
@@ -1,0 +1,7 @@
+package com.project.yogerOrder.payment.event.outbox.repository;
+
+import com.project.yogerOrder.payment.event.outbox.entity.PaymentOutboxEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentOutboxRepository extends JpaRepository<PaymentOutboxEntity, String> {
+}

--- a/src/main/java/com/project/yogerOrder/payment/event/outbox/service/PaymentOutboxService.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/outbox/service/PaymentOutboxService.java
@@ -1,0 +1,29 @@
+package com.project.yogerOrder.payment.event.outbox.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.yogerOrder.payment.event.outbox.entity.PaymentOutboxEntity;
+import com.project.yogerOrder.payment.event.outbox.repository.PaymentOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PaymentOutboxService {
+
+    private final PaymentOutboxRepository paymentOutboxRepository;
+
+    private final ObjectMapper objectMapper;
+
+    public void saveOutbox(String eventType, Object payload) {
+        try {
+            String stringPayload = objectMapper.writeValueAsString(payload);
+            paymentOutboxRepository.save(new PaymentOutboxEntity(eventType, stringPayload));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/src/main/java/com/project/yogerOrder/payment/event/outbox/service/PaymentOutboxService.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/outbox/service/PaymentOutboxService.java
@@ -2,6 +2,7 @@ package com.project.yogerOrder.payment.event.outbox.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.yogerOrder.payment.event.PaymentEventType;
 import com.project.yogerOrder.payment.event.outbox.entity.PaymentOutboxEntity;
 import com.project.yogerOrder.payment.event.outbox.repository.PaymentOutboxRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ public class PaymentOutboxService {
 
     private final ObjectMapper objectMapper;
 
-    public void saveOutbox(String eventType, Object payload) {
+    public void saveOutbox(PaymentEventType eventType, Object payload) {
         try {
             String stringPayload = objectMapper.writeValueAsString(payload);
             paymentOutboxRepository.save(new PaymentOutboxEntity(eventType, stringPayload));

--- a/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
@@ -6,6 +6,7 @@ import com.project.yogerOrder.payment.entity.PaymentState;
 import com.project.yogerOrder.payment.event.PaymentCanceledEvent;
 import com.project.yogerOrder.payment.event.PaymentCompletedEvent;
 import com.project.yogerOrder.payment.event.PaymentErroredEvent;
+import com.project.yogerOrder.payment.event.PaymentEventType;
 import com.project.yogerOrder.payment.event.outbox.service.PaymentOutboxService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,15 +35,15 @@ public class PaymentEventProducer {
     }
 
     private void publishPaymentCompletedEvent(PaymentEntity paymentEntity) {
-        paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentCompletedEvent.from(paymentEntity));
+        paymentOutboxService.saveOutbox(PaymentEventType.COMPLETED, PaymentCompletedEvent.from(paymentEntity));
     }
 
     private void publishPaymentCanceledEvent(PaymentEntity paymentEntity) {
-        paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentCanceledEvent.from(paymentEntity));
+        paymentOutboxService.saveOutbox(PaymentEventType.CANCELED, PaymentCanceledEvent.from(paymentEntity));
     }
 
     private void publishPaymentErroredEvent(PaymentEntity paymentEntity) {
-        paymentOutboxService.saveOutbox(paymentEntity.getState().toString(), PaymentErroredEvent.from(paymentEntity));
+        paymentOutboxService.saveOutbox(PaymentEventType.ERRORED, PaymentErroredEvent.from(paymentEntity));
     }
 
 }

--- a/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
@@ -28,9 +28,9 @@ public class PaymentEventProducer {
         } else if (paymentEntity.getState() == PaymentState.ERROR) {
             publishPaymentCanceledEvent(paymentEntity);
             publishPaymentErroredEvent(paymentEntity);
+        } else {
+            throw new IllegalArgumentException("Invalid payment state: " + paymentEntity.getState());
         }
-
-        throw new IllegalArgumentException("Invalid payment state: " + paymentEntity.getState());
     }
 
     private void publishPaymentCompletedEvent(PaymentEntity paymentEntity) {

--- a/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
@@ -1,8 +1,11 @@
-package com.project.yogerOrder.payment.event;
+package com.project.yogerOrder.payment.event.producer;
 
 
 import com.project.yogerOrder.payment.entity.PaymentEntity;
 import com.project.yogerOrder.payment.entity.PaymentState;
+import com.project.yogerOrder.payment.event.PaymentCanceledEvent;
+import com.project.yogerOrder.payment.event.PaymentCompletedEvent;
+import com.project.yogerOrder.payment.event.PaymentErroredEvent;
 import com.project.yogerOrder.payment.event.outbox.service.PaymentOutboxService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
@@ -8,7 +8,7 @@ import com.project.yogerOrder.payment.dto.request.PartialRefundRequestDTOs;
 import com.project.yogerOrder.payment.dto.request.VerifyPaymentRequestDTO;
 import com.project.yogerOrder.payment.dto.response.PaymentOrderDTO;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
-import com.project.yogerOrder.payment.event.PaymentEventProducer;
+import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
 import com.project.yogerOrder.payment.util.pg.dto.request.PGRefundRequestDTO;
 import com.project.yogerOrder.payment.util.pg.dto.resposne.PGPaymentInformResponseDTO;

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
@@ -109,7 +109,7 @@ public class PaymentService {
 
         if (isRefund) pgClientService.refund(new PGRefundRequestDTO(pgInform.pgPaymentId(), pgInform.amount()));
 
-        paymentEventProducer.sendEventByState(paymentEntity);
+        paymentEventProducer.publishEventByState(paymentEntity);
     }
 
     @Transactional
@@ -124,7 +124,7 @@ public class PaymentService {
 
             pgClientService.refund(new PGRefundRequestDTO(paymentEntity.getPgPaymentId(), paymentEntity.getAmount()));
 
-            paymentEventProducer.sendEventByState(paymentEntity);
+            paymentEventProducer.publishEventByState(paymentEntity);
         });
     }
 
@@ -168,6 +168,6 @@ public class PaymentService {
 
         paymentRepository.save(payment);
 
-        paymentEventProducer.sendEventByState(payment);
+        paymentEventProducer.publishEventByState(payment);
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
@@ -27,7 +27,7 @@ public class PaymentTransactionService {
         );
         paymentRepository.save(tempPayment);
 
-        paymentEventProducer.sendEventByState(tempPayment);
+        paymentEventProducer.publishEventByState(tempPayment);
     }
 
     @Transactional
@@ -35,6 +35,6 @@ public class PaymentTransactionService {
         paymentEntity.partialRefund(refundAmount);
         paymentRepository.save(paymentEntity);
 
-        paymentEventProducer.sendEventByState(paymentEntity);
+        paymentEventProducer.publishEventByState(paymentEntity);
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
@@ -2,7 +2,7 @@ package com.project.yogerOrder.payment.service;
 
 import com.project.yogerOrder.payment.dto.request.ConfirmPaymentRequestDTO;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
-import com.project.yogerOrder.payment.event.PaymentEventProducer;
+import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -54,10 +54,6 @@ management:
 kafka:
     admin:
         bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVER}
-    producer:
-        bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVER}
-        enable-idempotence: true
-        transaction-id-prefix: tx-
     consumer:
         bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVER}
         auto-offset-reset: earliest

--- a/src/test/java/com/project/yogerOrder/global/KafkaTestConfig.java
+++ b/src/test/java/com/project/yogerOrder/global/KafkaTestConfig.java
@@ -1,0 +1,49 @@
+package com.project.yogerOrder.global;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+
+@TestConfiguration
+@EnableConfigurationProperties(KafkaTestConfig.KafkaProducerConfigValue.class)
+public class KafkaTestConfig {
+
+    private final KafkaProducerConfigValue configValue;
+
+    public KafkaTestConfig(KafkaProducerConfigValue configValue) {
+        this.configValue = configValue;
+    }
+
+    @ConfigurationProperties(prefix = "kafka.producer")
+    public record KafkaProducerConfigValue(@NotBlank String bootstrapServers, @NotNull Boolean enableIdempotence,
+                                           @NotNull String transactionIdPrefix) {
+    }
+
+    private HashMap<String, Object> producerConfig() {
+        HashMap<String, Object> config = new HashMap<>();
+        System.out.println("configValue.bootstrapServers = " + configValue.bootstrapServers);
+
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, configValue.bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, configValue.enableIdempotence);
+        config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, configValue.transactionIdPrefix);
+
+        return config;
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> defaultKafkaTemplate() {
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(producerConfig()));
+    }
+}

--- a/src/test/java/com/project/yogerOrder/global/UsingTestContainerTest.java
+++ b/src/test/java/com/project/yogerOrder/global/UsingTestContainerTest.java
@@ -15,7 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 @ActiveProfiles("test")
-@Import(DBInitializer.class)
+@Import({DBInitializer.class, KafkaTestConfig.class})
 public abstract class UsingTestContainerTest {
     private static final String DB_USERNAME = "root";
     private static final String DB_PASSWORD = "1234";

--- a/src/test/java/com/project/yogerOrder/order/service/OrderServiceTest.java
+++ b/src/test/java/com/project/yogerOrder/order/service/OrderServiceTest.java
@@ -4,7 +4,7 @@ import com.project.yogerOrder.order.config.OrderConfig;
 import com.project.yogerOrder.order.dto.request.OrderRequestDTO;
 import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.entity.OrderState;
-import com.project.yogerOrder.order.event.OrderEventProducer;
+import com.project.yogerOrder.order.event.producer.OrderEventProducer;
 import com.project.yogerOrder.order.repository.OrderRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/project/yogerOrder/payment/PaymentIntegrationTest.java
+++ b/src/test/java/com/project/yogerOrder/payment/PaymentIntegrationTest.java
@@ -7,7 +7,7 @@ import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.event.OrderCanceledEvent;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
 import com.project.yogerOrder.payment.entity.PaymentState;
-import com.project.yogerOrder.payment.event.PaymentEventProducer;
+import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
 import com.project.yogerOrder.payment.util.pg.service.PGClientService;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/project/yogerOrder/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/project/yogerOrder/payment/service/PaymentServiceTest.java
@@ -8,7 +8,7 @@ import com.project.yogerOrder.payment.dto.request.PartialRefundRequestDTOs;
 import com.project.yogerOrder.payment.dto.request.VerifyPaymentRequestDTO;
 import com.project.yogerOrder.payment.dto.response.PaymentOrderDTO;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
-import com.project.yogerOrder.payment.event.PaymentEventProducer;
+import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
 import com.project.yogerOrder.payment.util.pg.dto.request.PGRefundRequestDTO;
 import com.project.yogerOrder.payment.util.pg.dto.resposne.PGPaymentInformResponseDTO;


### PR DESCRIPTION
### 작업 내용

---

kafkaTemplate를 통해서 이벤트를 발행하던 것을 transactional outbox pattern으로 전환하기 위하여 order와 payment의 outbox entity를 작성하고, 저장하는 기능을 구현하였습니다.

<br>

### 관련 이슈

---

close #17 

### 기타 사항

---

https://github.com/orgs/inha-2024-capstone/discussions/2