### PR TITLE
Refactor/#19: order, payment state 관리 개선

### DIFF
--- a/src/main/java/com/project/yogerOrder/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/yogerOrder/global/config/KafkaConfig.java
@@ -167,6 +167,8 @@ public class KafkaConfig {
                 TopicBuilder.name(OrderTopic.CREATED).build(),
                 TopicBuilder.name(OrderTopic.COMPLETED).build(),
                 TopicBuilder.name(OrderTopic.CANCELED).build(),
+                TopicBuilder.name(OrderTopic.DEDUCTION_AFTER_CANCELED).build(),
+                TopicBuilder.name(OrderTopic.PAYMENT_COMPLETED_AFTER_CANCELED).build(),
                 TopicBuilder.name(OrderTopic.ERRORED).build()
         );
     }

--- a/src/main/java/com/project/yogerOrder/global/util/stateMachine/Transition.java
+++ b/src/main/java/com/project/yogerOrder/global/util/stateMachine/Transition.java
@@ -1,0 +1,28 @@
+package com.project.yogerOrder.global.util.stateMachine;
+
+import lombok.Getter;
+
+public class Transition<S, E> {
+
+    private final S currentState;
+
+    private final E event;
+
+    @Getter
+    private final S nextState;
+
+    private final Runnable action;
+
+    public Transition(S currentState, E event, S nextState, Runnable action) {
+        this.currentState = currentState;
+        this.event = event;
+        this.nextState = nextState;
+        this.action = action;
+    }
+
+    public void runAction() {
+        if (action != null) {
+            action.run();
+        }
+    }
+}

--- a/src/main/java/com/project/yogerOrder/order/config/OrderTopic.java
+++ b/src/main/java/com/project/yogerOrder/order/config/OrderTopic.java
@@ -6,6 +6,8 @@ public class OrderTopic {
     public static final String CREATED = "yoger.order.prd.created";
     public static final String COMPLETED = "yoger.order.prd.completed";
     public static final String CANCELED = "yoger.order.prd.canceled";
+    public static final String DEDUCTION_AFTER_CANCELED = "yoger.order.prd.deductionAfterCanceled";
+    public static final String PAYMENT_COMPLETED_AFTER_CANCELED = "yoger.order.prd.paymentCompletedAfterCanceled";
     public static final String ERRORED = "yoger.order.prd.errored";
 
 
@@ -14,6 +16,8 @@ public class OrderTopic {
             case CREATED -> CREATED;
             case COMPLETED -> COMPLETED;
             case CANCELED -> CANCELED;
+            case DEDUCTION_AFTER_CANCELED -> DEDUCTION_AFTER_CANCELED;
+            case PAYMENT_COMPLETED_AFTER_CANCELED -> PAYMENT_COMPLETED_AFTER_CANCELED;
             case ERRORED -> ERRORED;
         };
     }

--- a/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
+++ b/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
@@ -57,7 +57,7 @@ public class OrderEntity extends BaseTimeEntity {
         if (this.state == OrderState.STOCK_CONFIRMED || this.state == OrderState.COMPLETED) return false;
         else if (this.state == OrderState.CREATED) this.state = OrderState.STOCK_CONFIRMED;
         else if (this.state == OrderState.PAYMENT_COMPLETED) this.state = OrderState.COMPLETED;
-        else this.state = OrderState.ERROR;
+        else this.state = OrderState.ERRORED;
 
         return true;
     }
@@ -66,7 +66,7 @@ public class OrderEntity extends BaseTimeEntity {
         if (this.state == OrderState.PAYMENT_COMPLETED || this.state == OrderState.COMPLETED) return false;
         else if (this.state == OrderState.CREATED) this.state = OrderState.PAYMENT_COMPLETED;
         else if (this.state == OrderState.STOCK_CONFIRMED) this.state = OrderState.COMPLETED;
-        else this.state = OrderState.ERROR;
+        else this.state = OrderState.ERRORED;
 
         return true;
     }
@@ -81,8 +81,8 @@ public class OrderEntity extends BaseTimeEntity {
     }
 
     public Boolean error() {
-        if (this.state == OrderState.ERROR) return false;
-        else this.state = OrderState.ERROR;
+        if (this.state == OrderState.ERRORED) return false;
+        else this.state = OrderState.ERRORED;
 
         return true;
     }

--- a/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
+++ b/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
@@ -55,11 +55,11 @@ public class OrderEntity extends BaseTimeEntity {
                 && getCreatedTime().isAfter(LocalDateTime.now().minusMinutes(validTime));
     }
 
-    public Boolean changeState(OrderStateChangeEvent orderStateChangeEvent) {
+    public Boolean changeStateIfChangeable(OrderStateChangeEvent orderStateChangeEvent) {
         OrderState nextState = OrderStaticStateMachine.nextState(this.state, orderStateChangeEvent);
-        boolean isUpdated = (this.state != nextState);
+        boolean isChanged = (this.state != nextState);
         this.state = nextState;
 
-        return isUpdated;
+        return isChanged;
     }
 }

--- a/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
+++ b/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
@@ -1,6 +1,8 @@
 package com.project.yogerOrder.order.entity;
 
 import com.project.yogerOrder.global.entity.BaseTimeEntity;
+import com.project.yogerOrder.order.util.stateMachine.OrderStateChangeEvent;
+import com.project.yogerOrder.order.util.stateMachine.OrderStaticStateMachine;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -53,37 +55,11 @@ public class OrderEntity extends BaseTimeEntity {
                 && getCreatedTime().isAfter(LocalDateTime.now().minusMinutes(validTime));
     }
 
-    public Boolean stockConfirmed() {
-        if (this.state == OrderState.STOCK_CONFIRMED || this.state == OrderState.COMPLETED) return false;
-        else if (this.state == OrderState.CREATED) this.state = OrderState.STOCK_CONFIRMED;
-        else if (this.state == OrderState.PAYMENT_COMPLETED) this.state = OrderState.COMPLETED;
-        else this.state = OrderState.ERRORED;
+    public Boolean changeState(OrderStateChangeEvent orderStateChangeEvent) {
+        OrderState nextState = OrderStaticStateMachine.nextState(this.state, orderStateChangeEvent);
+        boolean isUpdated = (this.state != nextState);
+        this.state = nextState;
 
-        return true;
-    }
-
-    public Boolean paymentCompleted() {
-        if (this.state == OrderState.PAYMENT_COMPLETED || this.state == OrderState.COMPLETED) return false;
-        else if (this.state == OrderState.CREATED) this.state = OrderState.PAYMENT_COMPLETED;
-        else if (this.state == OrderState.STOCK_CONFIRMED) this.state = OrderState.COMPLETED;
-        else this.state = OrderState.ERRORED;
-
-        return true;
-    }
-
-    public Boolean cancel() {
-        if (this.state == OrderState.CANCELED) return false;
-        else if (this.state != OrderState.CREATED && this.state != OrderState.STOCK_CONFIRMED && this.state != OrderState.PAYMENT_COMPLETED)
-            return error();
-        this.state = OrderState.CANCELED;
-
-        return true;
-    }
-
-    public Boolean error() {
-        if (this.state == OrderState.ERRORED) return false;
-        else this.state = OrderState.ERRORED;
-
-        return true;
+        return isUpdated;
     }
 }

--- a/src/main/java/com/project/yogerOrder/order/entity/OrderState.java
+++ b/src/main/java/com/project/yogerOrder/order/entity/OrderState.java
@@ -8,4 +8,12 @@ public enum OrderState {
     public static List<OrderState> getPayableStates() {
         return List.of(CREATED, STOCK_CONFIRMED);
     }
+
+    public static Boolean isStockOccupied(OrderState state) {
+        return state == STOCK_CONFIRMED || state == COMPLETED;
+    }
+
+    public static Boolean isPaymentCompleted(OrderState state) {
+        return state == PAYMENT_COMPLETED || state == COMPLETED;
+    }
 }

--- a/src/main/java/com/project/yogerOrder/order/entity/OrderState.java
+++ b/src/main/java/com/project/yogerOrder/order/entity/OrderState.java
@@ -3,7 +3,7 @@ package com.project.yogerOrder.order.entity;
 import java.util.List;
 
 public enum OrderState {
-    CREATED, STOCK_CONFIRMED, PAYMENT_COMPLETED, COMPLETED, CANCELED, ERROR;
+    CREATED, STOCK_CONFIRMED, PAYMENT_COMPLETED, COMPLETED, CANCELED, ERRORED;
 
     public static List<OrderState> getPayableStates() {
         return List.of(CREATED, STOCK_CONFIRMED);

--- a/src/main/java/com/project/yogerOrder/order/event/DeductionAfterOrderCanceledEvent.java
+++ b/src/main/java/com/project/yogerOrder/order/event/DeductionAfterOrderCanceledEvent.java
@@ -1,0 +1,28 @@
+package com.project.yogerOrder.order.event;
+
+import com.project.yogerOrder.order.entity.OrderEntity;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record DeductionAfterOrderCanceledEvent(@NotNull Long orderId, @NotBlank String eventId,
+                                               @NotNull OrderDeductionAfterCanceledData data, @NotNull LocalDateTime occurrenceTime) {
+
+    private record OrderDeductionAfterCanceledData(@NotNull Long userId, @NotNull Long productId, @NotNull Integer orderQuantity) {
+    }
+
+    public static DeductionAfterOrderCanceledEvent from(OrderEntity orderEntity) {
+        return new DeductionAfterOrderCanceledEvent(
+                orderEntity.getId(),
+                UUID.randomUUID().toString(),
+                new OrderDeductionAfterCanceledData(
+                        orderEntity.getBuyerId(),
+                        orderEntity.getProductId(),
+                        orderEntity.getQuantity()
+                ),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/project/yogerOrder/order/event/OrderCanceledEvent.java
+++ b/src/main/java/com/project/yogerOrder/order/event/OrderCanceledEvent.java
@@ -10,15 +10,21 @@ import java.util.UUID;
 public record OrderCanceledEvent(@NotNull Long orderId, @NotBlank String eventId, @NotNull OrderEventType eventType,
                                  @NotNull OrderCanceledData data, @NotNull LocalDateTime occurrenceTime) {
 
-    private record OrderCanceledData(@NotNull Long userId, @NotNull Long productId, @NotNull Integer orderQuantity) {
+    private record OrderCanceledData(@NotNull Long userId, @NotNull Long productId, @NotNull Integer orderQuantity, @NotNull Boolean stockOccupied, @NotNull Boolean isPaymentCompleted) {
     }
 
-    public static OrderCanceledEvent from(OrderEntity orderEntity) {
+    public static OrderCanceledEvent from(OrderEntity orderEntity, Boolean isStockOccupied, Boolean isPaymentCompleted) {
         return new OrderCanceledEvent(
                 orderEntity.getId(),
                 UUID.randomUUID().toString(),
                 OrderEventType.CANCELED,
-                new OrderCanceledData(orderEntity.getBuyerId(), orderEntity.getProductId(), orderEntity.getQuantity()),
+                new OrderCanceledData(
+                        orderEntity.getBuyerId(),
+                        orderEntity.getProductId(),
+                        orderEntity.getQuantity(),
+                        isStockOccupied,
+                        isPaymentCompleted
+                ),
                 LocalDateTime.now()
         );
     }

--- a/src/main/java/com/project/yogerOrder/order/event/OrderEventType.java
+++ b/src/main/java/com/project/yogerOrder/order/event/OrderEventType.java
@@ -1,5 +1,5 @@
 package com.project.yogerOrder.order.event;
 
 public enum OrderEventType {
-    CREATED, COMPLETED, CANCELED, ERRORED
+    CREATED, COMPLETED, CANCELED, DEDUCTION_AFTER_CANCELED, PAYMENT_COMPLETED_AFTER_CANCELED, ERRORED
 }

--- a/src/main/java/com/project/yogerOrder/order/event/PaymentCompletedAfterOrderCanceledEvent.java
+++ b/src/main/java/com/project/yogerOrder/order/event/PaymentCompletedAfterOrderCanceledEvent.java
@@ -1,0 +1,28 @@
+package com.project.yogerOrder.order.event;
+
+import com.project.yogerOrder.order.entity.OrderEntity;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PaymentCompletedAfterOrderCanceledEvent(@NotNull Long orderId, @NotBlank String eventId,
+                                                      @NotNull OrderDeductionAfterCanceledData data, @NotNull LocalDateTime occurrenceTime) {
+
+    private record OrderDeductionAfterCanceledData(@NotNull Long userId, @NotNull Long productId, @NotNull Integer orderQuantity) {
+    }
+
+    public static PaymentCompletedAfterOrderCanceledEvent from(OrderEntity orderEntity) {
+        return new PaymentCompletedAfterOrderCanceledEvent(
+                orderEntity.getId(),
+                UUID.randomUUID().toString(),
+                new OrderDeductionAfterCanceledData(
+                        orderEntity.getBuyerId(),
+                        orderEntity.getProductId(),
+                        orderEntity.getQuantity()
+                ),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
@@ -14,26 +14,23 @@ public class OrderEventProducer {
     private final OrderOutboxService orderOutboxService;
 
 
-    public void publishEventByState(OrderEntity orderEntity) {
-        if (orderEntity.getState() == OrderState.CREATED) {
-            publishOrderCreatedEvent(orderEntity);
-        } else if (orderEntity.getState() == OrderState.STOCK_CONFIRMED) {
-            // stock confirmed event ignored
-        } else if (orderEntity.getState() == OrderState.PAYMENT_COMPLETED) {
-            // payment completed event ignored
-        } else if (orderEntity.getState() == OrderState.COMPLETED) {
+    public void publishEventByState(OrderEntity orderEntity, OrderState beforeState) {
+        Boolean isStockOccupied = OrderState.isStockOccupied(beforeState);
+        Boolean isPaymentCompleted = OrderState.isPaymentCompleted(beforeState);
+
+        if (orderEntity.getState() == OrderState.COMPLETED) {
             publishOrderCompletedEvent(orderEntity);
         }  else if (orderEntity.getState() == OrderState.CANCELED) {
-            publishOrderCanceledEvent(orderEntity);
-        } else if (orderEntity.getState() == OrderState.ERROR) {
-            publishOrderCanceledEvent(orderEntity);
+            publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);
+        } else if (orderEntity.getState() == OrderState.ERRORED) {
+            publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);
             publishOrderErroredEvent(orderEntity);
         } else {
             throw new IllegalArgumentException("Invalid Order State" + orderEntity.getState());
         }
     }
 
-    private void publishOrderCreatedEvent(OrderEntity orderEntity) {
+    public void publishOrderCreatedEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(OrderEventType.CREATED, OrderCreatedEvent.from(orderEntity));
     }
 
@@ -41,22 +38,22 @@ public class OrderEventProducer {
         orderOutboxService.saveOutbox(OrderEventType.COMPLETED, OrderCompletedEvent.from(orderEntity));
     }
 
-    private void publishOrderCanceledEvent(OrderEntity orderEntity) {
-        orderOutboxService.saveOutbox(OrderEventType.CANCELED, OrderCanceledEvent.from(orderEntity));
+    private void publishOrderCanceledEvent(OrderEntity orderEntity, Boolean isStockOccupied, Boolean isPaymentCompleted) {
+        orderOutboxService.saveOutbox(OrderEventType.CANCELED, OrderCanceledEvent.from(orderEntity, isStockOccupied, isPaymentCompleted));
     }
 
     private void publishOrderErroredEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(OrderEventType.ERRORED, OrderErroredEvent.from(orderEntity));
     }
 
-    public void sendOrderDeductionAfterCanceledEvent(OrderEntity orderEntity) {
+    public void publishOrderDeductionAfterCanceledEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(
                 OrderEventType.DEDUCTION_AFTER_CANCELED,
                 DeductionAfterOrderCanceledEvent.from(orderEntity)
         );
     }
 
-    public void sendPaymentCompletedAfterOrderCanceledEvent(OrderEntity orderEntity) {
+    public void publishPaymentCompletedAfterOrderCanceledEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(
                 OrderEventType.PAYMENT_COMPLETED_AFTER_CANCELED,
                 PaymentCompletedAfterOrderCanceledEvent.from(orderEntity)

--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
@@ -2,61 +2,14 @@ package com.project.yogerOrder.order.event.producer;
 
 import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.entity.OrderState;
-import com.project.yogerOrder.order.event.*;
-import com.project.yogerOrder.order.event.outbox.service.OrderOutboxService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
-@RequiredArgsConstructor
-public class OrderEventProducer {
+public interface OrderEventProducer {
 
-    private final OrderOutboxService orderOutboxService;
+    void publishEventByState(OrderEntity orderEntity, OrderState beforeState);
 
+    void publishOrderCreatedEvent(OrderEntity orderEntity);
 
-    public void publishEventByState(OrderEntity orderEntity, OrderState beforeState) {
-        Boolean isStockOccupied = OrderState.isStockOccupied(beforeState);
-        Boolean isPaymentCompleted = OrderState.isPaymentCompleted(beforeState);
+    void publishOrderDeductionAfterCanceledEvent(OrderEntity orderEntity);
 
-        if (orderEntity.getState() == OrderState.COMPLETED) {
-            publishOrderCompletedEvent(orderEntity);
-        }  else if (orderEntity.getState() == OrderState.CANCELED) {
-            publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);
-        } else if (orderEntity.getState() == OrderState.ERRORED) {
-            publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);
-            publishOrderErroredEvent(orderEntity);
-        } else {
-            throw new IllegalArgumentException("Invalid Order State" + orderEntity.getState());
-        }
-    }
-
-    public void publishOrderCreatedEvent(OrderEntity orderEntity) {
-        orderOutboxService.saveOutbox(OrderEventType.CREATED, OrderCreatedEvent.from(orderEntity));
-    }
-
-    private void publishOrderCompletedEvent(OrderEntity orderEntity) {
-        orderOutboxService.saveOutbox(OrderEventType.COMPLETED, OrderCompletedEvent.from(orderEntity));
-    }
-
-    private void publishOrderCanceledEvent(OrderEntity orderEntity, Boolean isStockOccupied, Boolean isPaymentCompleted) {
-        orderOutboxService.saveOutbox(OrderEventType.CANCELED, OrderCanceledEvent.from(orderEntity, isStockOccupied, isPaymentCompleted));
-    }
-
-    private void publishOrderErroredEvent(OrderEntity orderEntity) {
-        orderOutboxService.saveOutbox(OrderEventType.ERRORED, OrderErroredEvent.from(orderEntity));
-    }
-
-    public void publishOrderDeductionAfterCanceledEvent(OrderEntity orderEntity) {
-        orderOutboxService.saveOutbox(
-                OrderEventType.DEDUCTION_AFTER_CANCELED,
-                DeductionAfterOrderCanceledEvent.from(orderEntity)
-        );
-    }
-
-    public void publishPaymentCompletedAfterOrderCanceledEvent(OrderEntity orderEntity) {
-        orderOutboxService.saveOutbox(
-                OrderEventType.PAYMENT_COMPLETED_AFTER_CANCELED,
-                PaymentCompletedAfterOrderCanceledEvent.from(orderEntity)
-        );
-    }
+    void publishPaymentCompletedAfterOrderCanceledEvent(OrderEntity orderEntity);
 }

--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderEventProducer.java
@@ -48,4 +48,18 @@ public class OrderEventProducer {
     private void publishOrderErroredEvent(OrderEntity orderEntity) {
         orderOutboxService.saveOutbox(OrderEventType.ERRORED, OrderErroredEvent.from(orderEntity));
     }
+
+    public void sendOrderDeductionAfterCanceledEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(
+                OrderEventType.DEDUCTION_AFTER_CANCELED,
+                DeductionAfterOrderCanceledEvent.from(orderEntity)
+        );
+    }
+
+    public void sendPaymentCompletedAfterOrderCanceledEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(
+                OrderEventType.PAYMENT_COMPLETED_AFTER_CANCELED,
+                PaymentCompletedAfterOrderCanceledEvent.from(orderEntity)
+        );
+    }
 }

--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderOutboxEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderOutboxEventProducer.java
@@ -1,0 +1,64 @@
+package com.project.yogerOrder.order.event.producer;
+
+import com.project.yogerOrder.order.entity.OrderEntity;
+import com.project.yogerOrder.order.entity.OrderState;
+import com.project.yogerOrder.order.event.*;
+import com.project.yogerOrder.order.event.outbox.service.OrderOutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderOutboxEventProducer implements OrderEventProducer {
+
+    private final OrderOutboxService orderOutboxService;
+
+    @Override
+    public void publishEventByState(OrderEntity orderEntity, OrderState beforeState) {
+        Boolean isStockOccupied = OrderState.isStockOccupied(beforeState);
+        Boolean isPaymentCompleted = OrderState.isPaymentCompleted(beforeState);
+
+        if (orderEntity.getState() == OrderState.COMPLETED) {
+            publishOrderCompletedEvent(orderEntity);
+        }  else if (orderEntity.getState() == OrderState.CANCELED) {
+            publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);
+        } else if (orderEntity.getState() == OrderState.ERRORED) {
+            publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);
+            publishOrderErroredEvent(orderEntity);
+        } else {
+            throw new IllegalArgumentException("Invalid Order State" + orderEntity.getState());
+        }
+    }
+
+    @Override
+    public void publishOrderCreatedEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.CREATED, OrderCreatedEvent.from(orderEntity));
+    }
+
+    private void publishOrderCompletedEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.COMPLETED, OrderCompletedEvent.from(orderEntity));
+    }
+
+    private void publishOrderCanceledEvent(OrderEntity orderEntity, Boolean isStockOccupied, Boolean isPaymentCompleted) {
+        orderOutboxService.saveOutbox(OrderEventType.CANCELED, OrderCanceledEvent.from(orderEntity, isStockOccupied, isPaymentCompleted));
+    }
+
+    private void publishOrderErroredEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(OrderEventType.ERRORED, OrderErroredEvent.from(orderEntity));
+    }
+
+    @Override
+    public void publishOrderDeductionAfterCanceledEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(
+                OrderEventType.DEDUCTION_AFTER_CANCELED,
+                DeductionAfterOrderCanceledEvent.from(orderEntity)
+        );
+    }
+
+    public void publishPaymentCompletedAfterOrderCanceledEvent(OrderEntity orderEntity) {
+        orderOutboxService.saveOutbox(
+                OrderEventType.PAYMENT_COMPLETED_AFTER_CANCELED,
+                PaymentCompletedAfterOrderCanceledEvent.from(orderEntity)
+        );
+    }
+}

--- a/src/main/java/com/project/yogerOrder/order/service/OrderService.java
+++ b/src/main/java/com/project/yogerOrder/order/service/OrderService.java
@@ -129,7 +129,7 @@ public class OrderService {
     }
 
     private void updateByStateChange(OrderEntity orderEntity, OrderStateChangeEvent orderStateChangeEvent) {
-        if (!orderEntity.changeState(orderStateChangeEvent)) {
+        if (!orderEntity.changeStateIfChangeable(orderStateChangeEvent)) {
             log.debug("Order is already in the target state. orderId: {}", orderEntity.getId());
             return;
         }

--- a/src/main/java/com/project/yogerOrder/order/service/OrderService.java
+++ b/src/main/java/com/project/yogerOrder/order/service/OrderService.java
@@ -11,6 +11,7 @@ import com.project.yogerOrder.order.entity.OrderState;
 import com.project.yogerOrder.order.event.producer.OrderEventProducer;
 import com.project.yogerOrder.order.exception.OrderNotFoundException;
 import com.project.yogerOrder.order.repository.OrderRepository;
+import com.project.yogerOrder.order.util.stateMachine.OrderStateChangeEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -76,69 +77,39 @@ public class OrderService {
     @Transactional
     public void updateByDeductionSuccess(Long orderId) {
         OrderEntity orderEntity = findById(orderId);
-        Boolean isUpdated = orderEntity.stockConfirmed();
-        if (!isUpdated) {
-            log.debug("Order is already completed. orderId: {}", orderEntity.getId());
+
+        if (orderEntity.getState() == OrderState.CANCELED) {
+            orderEventProducer.publishEventByState(orderEntity);
             return;
         }
-        orderRepository.save(orderEntity);
 
-        orderEventProducer.publishEventByState(orderEntity);
+        updateByStateChange(orderEntity, OrderStateChangeEvent.STOCK_DEDUCTED);
     }
 
     @Transactional
     public void updateByDeductionFail(Long orderId) {
+        updateByStateChange(findById(orderId), OrderStateChangeEvent.CANCELED);
+    }
+
+    @Transactional
+    public void updateByPaymentCompleted(Long orderId) {
         OrderEntity orderEntity = findById(orderId);
-        Boolean isUpdated = orderEntity.cancel();
-        if (!isUpdated) {
-            log.debug("Order is already canceled. orderId: {}", orderEntity.getId());
+
+        if (orderEntity.getState() == OrderState.CANCELED) {
+            orderEventProducer.publishEventByState(orderEntity);
             return;
         }
-        orderRepository.save(orderEntity);
 
-        orderEventProducer.publishEventByState(orderEntity);
+        updateByStateChange(orderEntity, OrderStateChangeEvent.PAID);
     }
 
     @Transactional
-    public void updateByPaymentCompleted(Long id) {
-        OrderEntity orderEntity = findById(id);
-        Boolean isUpdated = orderEntity.paymentCompleted();
-        if (!isUpdated) {
-            log.debug("Order is already completed. orderId: {}", orderEntity.getId());
-            return;
-        }
-        orderRepository.save(orderEntity);
-
-        orderEventProducer.publishEventByState(orderEntity);
+    public void updateByPaymentCanceled(Long orderId) {
+        updateByStateChange(findById(orderId), OrderStateChangeEvent.CANCELED);
     }
-
-    @Transactional
-    public void updateByPaymentCanceled(Long id) {
-        OrderEntity orderEntity = findById(id);
-        Boolean isUpdated = orderEntity.cancel();
-        if (!isUpdated) {
-            log.debug("Order is already canceled. orderId: {}", orderEntity.getId());
-            return;
-        }
-        orderRepository.save(orderEntity);
-
-        orderEventProducer.publishEventByState(orderEntity);
-    }
-
-    @Transactional
-    public void updateByExpiration(OrderEntity orderEntity) {
-        Boolean isUpdated = orderEntity.cancel();
-        if (!isUpdated) {
-            log.debug("Order is already canceled. orderId: {}", orderEntity.getId());
-            return;
-        }
-        orderRepository.save(orderEntity);
-
-        orderEventProducer.publishEventByState(orderEntity);
-    }
-
 
     // 주기적 pending 상태 order를 만료 상태로 변경하고 상품 재고 release
+    @Transactional
     @Scheduled(cron = "${order.cron.expiration}")
     @SchedulerLock(name = "orderExpirationSchedule", lockAtMostFor = "PT50S", lockAtLeastFor = "PT40S")
     public void orderExpirationSchedule() {
@@ -150,5 +121,21 @@ public class OrderService {
         );
 
         log.info("Pending order expiration schedule successfully executed");
+    }
+
+
+    private void updateByExpiration(OrderEntity orderEntity) {
+        updateByStateChange(orderEntity, OrderStateChangeEvent.CANCELED);
+    }
+
+    private void updateByStateChange(OrderEntity orderEntity, OrderStateChangeEvent orderStateChangeEvent) {
+        if (!orderEntity.changeState(orderStateChangeEvent)) {
+            log.debug("Order is already in the target state. orderId: {}", orderEntity.getId());
+            return;
+        }
+
+        orderRepository.save(orderEntity);
+
+        orderEventProducer.publishEventByState(orderEntity);
     }
 }

--- a/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStateChangeEvent.java
+++ b/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStateChangeEvent.java
@@ -1,0 +1,5 @@
+package com.project.yogerOrder.order.util.stateMachine;
+
+public enum OrderStateChangeEvent {
+    STOCK_DEDUCTED, PAID, CANCELED, ERROR;
+}

--- a/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStateChangeEvent.java
+++ b/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStateChangeEvent.java
@@ -1,5 +1,5 @@
 package com.project.yogerOrder.order.util.stateMachine;
 
 public enum OrderStateChangeEvent {
-    STOCK_DEDUCTED, PAID, CANCELED, ERROR;
+    STOCK_DEDUCTED, PAID, CANCELED, ERRORED;
 }

--- a/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStaticStateMachine.java
+++ b/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStaticStateMachine.java
@@ -1,0 +1,54 @@
+package com.project.yogerOrder.order.util.stateMachine;
+
+import com.project.yogerOrder.global.util.stateMachine.Transition;
+import com.project.yogerOrder.order.entity.OrderState;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class OrderStaticStateMachine {
+
+    private static final Map<OrderState, Map<OrderStateChangeEvent, Transition<OrderState, OrderStateChangeEvent>>> transitions = new ConcurrentHashMap<>();
+
+    private static final OrderState errorState = OrderState.ERRORED;
+    
+    static {
+        entryTransition(OrderState.CREATED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.STOCK_CONFIRMED);
+        entryTransition(OrderState.CREATED, OrderStateChangeEvent.PAID, OrderState.PAYMENT_COMPLETED);
+        entryTransition(OrderState.CREATED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+
+        entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.PAID, OrderState.COMPLETED);
+        entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.STOCK_CONFIRMED);
+
+        entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.COMPLETED);
+        entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.PAID, OrderState.PAYMENT_COMPLETED);
+
+        entryTransition(OrderState.COMPLETED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.COMPLETED);
+        entryTransition(OrderState.COMPLETED, OrderStateChangeEvent.PAID, OrderState.COMPLETED);
+        entryTransition(OrderState.COMPLETED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+
+        entryTransition(OrderState.CANCELED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.CANCELED);
+        entryTransition(OrderState.CANCELED, OrderStateChangeEvent.PAID, OrderState.CANCELED);
+        entryTransition(OrderState.CANCELED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+    }
+
+    private static void entryTransition(OrderState currentState, OrderStateChangeEvent event, OrderState nextState) {
+        entryTransition(currentState, event, nextState, null);
+    }
+
+    private static void entryTransition(OrderState currentState, OrderStateChangeEvent event, OrderState nextState, Runnable action) {
+        transitions.putIfAbsent(currentState, new ConcurrentHashMap<>());
+        transitions.get(currentState).put(event, new Transition<>(currentState, event, nextState, action));
+    }
+
+    public static OrderState nextState(OrderState currentState, OrderStateChangeEvent event) {
+        Transition<OrderState, OrderStateChangeEvent> transition = transitions.get(currentState).get(event);
+        if (transition == null) return errorState;
+
+        transition.runAction();
+
+        return transition.getNextState();
+    }
+}

--- a/src/main/java/com/project/yogerOrder/payment/controller/PaymentController.java
+++ b/src/main/java/com/project/yogerOrder/payment/controller/PaymentController.java
@@ -1,6 +1,5 @@
 package com.project.yogerOrder.payment.controller;
 
-import com.project.yogerOrder.payment.dto.request.PartialRefundRequestDTOs;
 import com.project.yogerOrder.payment.dto.request.PortOnePaymentWebhookRequestDTO;
 import com.project.yogerOrder.payment.dto.request.VerifyPaymentRequestDTO;
 import com.project.yogerOrder.payment.service.PaymentService;
@@ -23,13 +22,6 @@ public class PaymentController {
     @PostMapping("/verify")
     public ResponseEntity<Void> verifyPaymentWebhook(@RequestBody @Valid PortOnePaymentWebhookRequestDTO portOnePaymentWebhookRequestDTO) {
         paymentService.verifyPayment(VerifyPaymentRequestDTO.from(portOnePaymentWebhookRequestDTO));
-
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-
-    @PostMapping("/products/expire")
-    public ResponseEntity<Void> productExpired(@RequestBody @Valid PartialRefundRequestDTOs partialRefundRequestDTOs) {
-        paymentService.productsExpiration(partialRefundRequestDTOs);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/com/project/yogerOrder/payment/dto/request/PartialRefundRequestDTO.java
+++ b/src/main/java/com/project/yogerOrder/payment/dto/request/PartialRefundRequestDTO.java
@@ -1,9 +1,0 @@
-package com.project.yogerOrder.payment.dto.request;
-
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-
-public record PartialRefundRequestDTO(@NotNull Long productId,
-                                      @NotNull @Min(0) Integer originalMaxPrice,
-                                      @NotNull @Min(0) Integer confirmedPrice) {
-}

--- a/src/main/java/com/project/yogerOrder/payment/dto/request/PartialRefundRequestDTOs.java
+++ b/src/main/java/com/project/yogerOrder/payment/dto/request/PartialRefundRequestDTOs.java
@@ -1,6 +1,0 @@
-package com.project.yogerOrder.payment.dto.request;
-
-import java.util.List;
-
-public record PartialRefundRequestDTOs(List<PartialRefundRequestDTO> partialRefundRequestDTOs) {
-}

--- a/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
+++ b/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
@@ -1,6 +1,8 @@
 package com.project.yogerOrder.payment.entity;
 
 import com.project.yogerOrder.global.entity.BaseTimeEntity;
+import com.project.yogerOrder.payment.util.stateMachine.PaymentStateChangeEvent;
+import com.project.yogerOrder.payment.util.stateMachine.PaymentStaticStateMachine;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -74,23 +76,11 @@ public class PaymentEntity extends BaseTimeEntity {
         this.refundedAmount = refundAmount;
     }
 
-    public Boolean updateToCanceledState() {
-        if (this.state == PaymentState.CANCELED) {
-            return false;
-        } else if (this.state == PaymentState.PAID) {
-            this.state = PaymentState.CANCELED;
+    public Boolean changeStateIfChangeable(PaymentStateChangeEvent paymentStateChangeEvent) {
+        PaymentState nextState = PaymentStaticStateMachine.nextState(this.state, paymentStateChangeEvent);
+        boolean isChanged = (this.state != nextState);
+        this.state = nextState;
 
-            return true;
-        } else {
-            throw new IllegalStateException("This payment is not cancelable");
-        }
-    }
-
-    public Boolean updateToErrorState() {
-        if (this.state == PaymentState.ERRORED) return false;
-
-        this.state = PaymentState.ERRORED;
-
-        return true;
+        return isChanged;
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
+++ b/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
@@ -51,8 +51,8 @@ public class PaymentEntity extends BaseTimeEntity {
         this.state = state;
     }
 
-    public static PaymentEntity createTempPaidPayment(String impUid, Long orderId, Integer amount, Long userId) {
-        return new PaymentEntity(impUid, orderId, amount, userId, PaymentState.TEMPORARY_PAID);
+    public static PaymentEntity createPaidPayment(String impUid, Long orderId, Integer amount, Long userId) {
+        return new PaymentEntity(impUid, orderId, amount, userId, PaymentState.PAID);
     }
 
     public static PaymentEntity createCanceledPayment(String impUid, Long orderId, Integer amount, Long userId) {
@@ -64,24 +64,20 @@ public class PaymentEntity extends BaseTimeEntity {
     }
 
     public Boolean isPartialRefundable(Integer refundAmount) {
-        return (refundAmount < this.amount) && (this.refundedAmount == 0) && (this.state == PaymentState.TEMPORARY_PAID);
+        return (refundAmount < this.amount) && (this.refundedAmount == 0) && (this.state == PaymentState.PAID);
     }
 
-    public void partialRefund(Integer refundAmount) {
+    public void refund(Integer refundAmount) {
         if (!isPartialRefundable(refundAmount)) throw new IllegalStateException("This payment is not refundable");
 
-        this.state = PaymentState.PAID_END;
+        this.state = PaymentState.CANCELED;
         this.refundedAmount = refundAmount;
-    }
-
-    public boolean isPayCompletable() {
-        return this.state == PaymentState.TEMPORARY_PAID;
     }
 
     public Boolean updateToCanceledState() {
         if (this.state == PaymentState.CANCELED) {
             return false;
-        } else if (this.state == PaymentState.TEMPORARY_PAID || this.state == PaymentState.PAID_END) {
+        } else if (this.state == PaymentState.PAID) {
             this.state = PaymentState.CANCELED;
 
             return true;

--- a/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
+++ b/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
@@ -60,7 +60,7 @@ public class PaymentEntity extends BaseTimeEntity {
     }
 
     public static PaymentEntity createErrorPayment(String impUid, Long orderId, Integer amount, Long userId) {
-        return new PaymentEntity(impUid, orderId, amount, userId, PaymentState.ERROR);
+        return new PaymentEntity(impUid, orderId, amount, userId, PaymentState.ERRORED);
     }
 
     public Boolean isPartialRefundable(Integer refundAmount) {
@@ -87,9 +87,9 @@ public class PaymentEntity extends BaseTimeEntity {
     }
 
     public Boolean updateToErrorState() {
-        if (this.state == PaymentState.ERROR) return false;
+        if (this.state == PaymentState.ERRORED) return false;
 
-        this.state = PaymentState.ERROR;
+        this.state = PaymentState.ERRORED;
 
         return true;
     }

--- a/src/main/java/com/project/yogerOrder/payment/entity/PaymentState.java
+++ b/src/main/java/com/project/yogerOrder/payment/entity/PaymentState.java
@@ -1,5 +1,5 @@
 package com.project.yogerOrder.payment.entity;
 
 public enum PaymentState {
-    TEMPORARY_PAID, PAID_END, CANCELED, ERROR
+    PAID, CANCELED, ERROR
 }

--- a/src/main/java/com/project/yogerOrder/payment/entity/PaymentState.java
+++ b/src/main/java/com/project/yogerOrder/payment/entity/PaymentState.java
@@ -1,5 +1,5 @@
 package com.project.yogerOrder.payment.entity;
 
 public enum PaymentState {
-    PAID, CANCELED, ERROR
+    PAID, CANCELED, ERRORED
 }

--- a/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
@@ -24,7 +24,7 @@ public class PaymentEventProducer {
             publishPaymentCompletedEvent(paymentEntity);
         } else if (paymentEntity.getState() == PaymentState.CANCELED) {
             publishPaymentCanceledEvent(paymentEntity);
-        } else if (paymentEntity.getState() == PaymentState.ERROR) {
+        } else if (paymentEntity.getState() == PaymentState.ERRORED) {
             publishPaymentCanceledEvent(paymentEntity);
             publishPaymentErroredEvent(paymentEntity);
         } else {

--- a/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/payment/event/producer/PaymentEventProducer.java
@@ -20,9 +20,7 @@ public class PaymentEventProducer {
     private final PaymentOutboxService paymentOutboxService;
 
     public void publishEventByState(PaymentEntity paymentEntity) {
-        if (paymentEntity.getState() == PaymentState.TEMPORARY_PAID) {
-            // temporary paid payment is ignored
-        } else if (paymentEntity.getState() == PaymentState.PAID_END) {
+        if (paymentEntity.getState() == PaymentState.PAID) {
             publishPaymentCompletedEvent(paymentEntity);
         } else if (paymentEntity.getState() == PaymentState.CANCELED) {
             publishPaymentCanceledEvent(paymentEntity);

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
@@ -10,6 +10,7 @@ import com.project.yogerOrder.payment.repository.PaymentRepository;
 import com.project.yogerOrder.payment.util.pg.dto.request.PGRefundRequestDTO;
 import com.project.yogerOrder.payment.util.pg.dto.resposne.PGPaymentInformResponseDTO;
 import com.project.yogerOrder.payment.util.pg.service.PGClientService;
+import com.project.yogerOrder.payment.util.stateMachine.PaymentStateChangeEvent;
 import com.project.yogerOrder.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -110,7 +111,7 @@ public class PaymentService {
     @Transactional
     public void orderCanceled(Long orderId) {
         paymentRepository.findByOrderId(orderId).ifPresent(paymentEntity -> {
-            Boolean isUpdated = paymentEntity.updateToCanceledState();
+            Boolean isUpdated = paymentEntity.changeStateIfChangeable(PaymentStateChangeEvent.ORDER_CANCELED);
             if (!isUpdated) {
                 log.debug("payment {} is already canceled", paymentEntity.getId());
                 return;

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
@@ -3,10 +3,7 @@ package com.project.yogerOrder.payment.service;
 import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.service.OrderService;
 import com.project.yogerOrder.payment.dto.request.ConfirmPaymentRequestDTO;
-import com.project.yogerOrder.payment.dto.request.PartialRefundRequestDTO;
-import com.project.yogerOrder.payment.dto.request.PartialRefundRequestDTOs;
 import com.project.yogerOrder.payment.dto.request.VerifyPaymentRequestDTO;
-import com.project.yogerOrder.payment.dto.response.PaymentOrderDTO;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
 import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
@@ -18,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -72,7 +67,7 @@ public class PaymentService {
         if (pgInform.amount() != (originalMaxPrice * orderEntity.getQuantity())) { // 내부
             log.error("PG payment {} is invalid", pgInform.pgPaymentId());
             PaymentEntity errorPayment = cancelPaymentByError(orderEntity, pgInform);
-            saveCanceledPayment(errorPayment, pgInform, false);
+            saveCanceledPayment(errorPayment, pgInform, true);
 
             return;
         }
@@ -126,48 +121,5 @@ public class PaymentService {
 
             paymentEventProducer.publishEventByState(paymentEntity);
         });
-    }
-
-    public void productsExpiration(PartialRefundRequestDTOs partialRefundRequestDTOs) {
-        partialRefundRequestDTOs.partialRefundRequestDTOs().forEach(this::expirationRefundPerProduct);
-    }
-
-    private void expirationRefundPerProduct(PartialRefundRequestDTO partialRefundRequestDTO) {
-        Long productId = partialRefundRequestDTO.productId();
-        for (PaymentOrderDTO paymentOrderDTO : paymentRepository.findAllPaymentAndOrderByProductId(productId)) {
-            PaymentEntity payment = paymentOrderDTO.payment();
-            OrderEntity order = paymentOrderDTO.order();
-            int refundAmountPerQuantity = partialRefundRequestDTO.originalMaxPrice() - partialRefundRequestDTO.confirmedPrice();
-            int refundAmount = refundAmountPerQuantity * order.getQuantity();
-            int checksum = payment.getAmount();
-
-            if (!payment.isPayCompletable()) {
-                log.error("payment {} is in invalid state", payment.getId());
-                updateByError(payment);
-                continue;
-            }
-            if (!Objects.equals(payment.getAmount(), partialRefundRequestDTO.originalMaxPrice() * order.getQuantity())
-                    || !payment.isPartialRefundable(refundAmount)) {
-                log.error("Failed to partial refund payment {} from PG", payment.getId());
-                updateByError(payment);
-                continue;
-            }
-
-            // 외부 API 장애에 따라 db state가 영향받지 않도록, 외부 API 호출이 완료되면 entity를 update하도록 작성
-            pgClientService.refund(new PGRefundRequestDTO(payment.getPgPaymentId(), checksum, refundAmount));
-            paymentTransactionService.refund(payment, refundAmount);
-        }
-    }
-
-    private void updateByError(PaymentEntity payment) {
-        Boolean isUpdated = payment.updateToErrorState();
-        if (!isUpdated) {
-            log.debug("payment {} is already errored", payment.getId());
-            return;
-        }
-
-        paymentRepository.save(payment);
-
-        paymentEventProducer.publishEventByState(payment);
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
@@ -19,20 +19,20 @@ public class PaymentTransactionService {
 
     @Transactional
     public void confirmPayment(ConfirmPaymentRequestDTO confirmPaymentRequestDTO) {
-        PaymentEntity tempPayment = PaymentEntity.createTempPaidPayment(
+        PaymentEntity paymentEntity = PaymentEntity.createPaidPayment(
                 confirmPaymentRequestDTO.pgPaymentId(),
                 confirmPaymentRequestDTO.orderId(),
                 confirmPaymentRequestDTO.amount(),
                 confirmPaymentRequestDTO.buyerId()
         );
-        paymentRepository.save(tempPayment);
+        paymentRepository.save(paymentEntity);
 
-        paymentEventProducer.publishEventByState(tempPayment);
+        paymentEventProducer.publishEventByState(paymentEntity);
     }
 
     @Transactional
     public void refund(PaymentEntity paymentEntity, Integer refundAmount) {
-        paymentEntity.partialRefund(refundAmount);
+        paymentEntity.refund(refundAmount);
         paymentRepository.save(paymentEntity);
 
         paymentEventProducer.publishEventByState(paymentEntity);

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
@@ -29,12 +29,4 @@ public class PaymentTransactionService {
 
         paymentEventProducer.publishEventByState(paymentEntity);
     }
-
-    @Transactional
-    public void refund(PaymentEntity paymentEntity, Integer refundAmount) {
-        paymentEntity.refund(refundAmount);
-        paymentRepository.save(paymentEntity);
-
-        paymentEventProducer.publishEventByState(paymentEntity);
-    }
 }

--- a/src/main/java/com/project/yogerOrder/payment/util/stateMachine/PaymentStateChangeEvent.java
+++ b/src/main/java/com/project/yogerOrder/payment/util/stateMachine/PaymentStateChangeEvent.java
@@ -1,0 +1,5 @@
+package com.project.yogerOrder.payment.util.stateMachine;
+
+public enum PaymentStateChangeEvent {
+    ORDER_CANCELED, REFUNDED, ERRORED
+}

--- a/src/main/java/com/project/yogerOrder/payment/util/stateMachine/PaymentStaticStateMachine.java
+++ b/src/main/java/com/project/yogerOrder/payment/util/stateMachine/PaymentStaticStateMachine.java
@@ -1,0 +1,36 @@
+package com.project.yogerOrder.payment.util.stateMachine;
+
+import com.project.yogerOrder.global.util.stateMachine.Transition;
+import com.project.yogerOrder.payment.entity.PaymentState;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PaymentStaticStateMachine {
+
+    private static final Map<PaymentState, Map<PaymentStateChangeEvent, Transition<PaymentState, PaymentStateChangeEvent>>> transitions = new ConcurrentHashMap<>();
+
+    private static final PaymentState errorState = PaymentState.ERRORED;
+
+    static {
+        entryTransition(PaymentState.PAID, PaymentStateChangeEvent.ORDER_CANCELED, PaymentState.CANCELED);
+    }
+
+    private static void entryTransition(PaymentState currentState, PaymentStateChangeEvent event, PaymentState nextState) {
+        entryTransition(currentState, event, nextState, null);
+    }
+
+    private static void entryTransition(PaymentState currentState, PaymentStateChangeEvent event, PaymentState nextState, Runnable action) {
+        transitions.putIfAbsent(currentState, new ConcurrentHashMap<>());
+        transitions.get(currentState).put(event, new Transition<>(currentState, event, nextState, action));
+    }
+
+    public static PaymentState nextState(PaymentState currentState, PaymentStateChangeEvent event) {
+        Transition<PaymentState, PaymentStateChangeEvent> transition = transitions.get(currentState).get(event);
+        if (transition == null) return errorState;
+
+        transition.runAction();
+
+        return transition.getNextState();
+    }
+}

--- a/src/test/java/com/project/yogerOrder/order/OrderIntegrationTest.java
+++ b/src/test/java/com/project/yogerOrder/order/OrderIntegrationTest.java
@@ -165,7 +165,7 @@ public class OrderIntegrationTest extends UsingTestContainerTest {
                         OrderState.COMPLETED,
                         deductionFailedEvent,
                         ProductTopic.DEDUCTION_FAILED,
-                        OrderState.ERROR
+                        OrderState.ERRORED
                 ),
                 Arguments.of(
                         OrderState.COMPLETED,
@@ -177,7 +177,7 @@ public class OrderIntegrationTest extends UsingTestContainerTest {
                         OrderState.COMPLETED,
                         paymentFailedEvent,
                         PaymentTopic.CANCELED,
-                        OrderState.ERROR
+                        OrderState.ERRORED
                 )
         );
     }

--- a/src/test/java/com/project/yogerOrder/order/service/OrderServiceTest.java
+++ b/src/test/java/com/project/yogerOrder/order/service/OrderServiceTest.java
@@ -83,7 +83,7 @@ class OrderServiceTest {
     private static Stream<Arguments> isPayableSource() {
         return Stream.of(
                 Arguments.of(OrderState.CREATED, 4, true),
-                Arguments.of(OrderState.ERROR, 4, false),
+                Arguments.of(OrderState.ERRORED, 4, false),
                 Arguments.of(OrderState.CANCELED, 4, false),
                 Arguments.of(OrderState.COMPLETED, 4, false),
                 Arguments.of(OrderState.CREATED, 6, false)

--- a/src/test/java/com/project/yogerOrder/payment/PaymentIntegrationTest.java
+++ b/src/test/java/com/project/yogerOrder/payment/PaymentIntegrationTest.java
@@ -53,14 +53,14 @@ public class PaymentIntegrationTest extends UsingTestContainerTest {
 
 
         // payment entity 생성 후 저장
-        PaymentEntity tempPaidPayment = PaymentEntity.createTempPaidPayment(impUid, orderId, amount, userId);
+        PaymentEntity tempPaidPayment = PaymentEntity.createPaidPayment(impUid, orderId, amount, userId);
         ReflectionTestUtils.setField(tempPaidPayment, "id", paymentId); // id 설정
         paymentRepository.save(tempPaidPayment);
 
         // orderCanceledEvent 생성을 위한 order entity 생성 후 활용
         OrderEntity orderEntity = OrderEntity.createPendingOrder(productId, quantity, userId);
         ReflectionTestUtils.setField(orderEntity, "id", orderId); // id 설정
-        OrderCanceledEvent orderCanceledEvent = OrderCanceledEvent.from(orderEntity);
+        OrderCanceledEvent orderCanceledEvent = OrderCanceledEvent.from(orderEntity, false, false);
 
 
         // when

--- a/src/test/java/com/project/yogerOrder/payment/repository/PaymentRepositoryTest.java
+++ b/src/test/java/com/project/yogerOrder/payment/repository/PaymentRepositoryTest.java
@@ -34,7 +34,7 @@ class PaymentRepositoryTest extends CommonRepositoryTest {
         OrderEntity orderEntity = OrderEntity.createPendingOrder(productId, quantity, userId);
         Long orderId = orderRepository.save(orderEntity).getId();
 
-        PaymentEntity paymentEntity = PaymentEntity.createTempPaidPayment(pgId, orderId, totalAmount, userId);
+        PaymentEntity paymentEntity = PaymentEntity.createPaidPayment(pgId, orderId, totalAmount, userId);
         paymentRepository.save(paymentEntity);
 
         // when


### PR DESCRIPTION
### 작업 내용

---

복잡한 order와 payment의 state 관리와 transition 관리를 각각의 finite state machine을 만들어 관리할 수 있도록 개선하였습니다.

- close #13 Boolean을 유지하되, 메서드의 이름을 변경하여, Boolean이 의미하는 것을 더 명확히 하도록 개선하였습니다.
- close #14 Error state 발생 시, kafka의 error topic에 이벤트를 발행하게 만들어, 추후에 대응할 수 있도록 개선하였습니다.
- close #16 payment state machine을 구성하는 과정에서 비유효한 TEMPORARY_PAID 상태를 제거하였습니다.


<br>

### 관련 이슈

---

- close #19 

### 기타 사항

---

