### PR TITLE
Fix/#22: order canceled event 대응 추가

### DIFF
--- a/src/main/java/com/project/yogerOrder/order/event/producer/OrderOutboxEventProducer.java
+++ b/src/main/java/com/project/yogerOrder/order/event/producer/OrderOutboxEventProducer.java
@@ -20,7 +20,11 @@ public class OrderOutboxEventProducer implements OrderEventProducer {
 
         if (orderEntity.getState() == OrderState.COMPLETED) {
             publishOrderCompletedEvent(orderEntity);
-        }  else if (orderEntity.getState() == OrderState.CANCELED) {
+        } else if (orderEntity.getState() == OrderState.STOCK_CONFIRMED) {
+            // do nothing
+        } else if (orderEntity.getState() == OrderState.PAYMENT_COMPLETED) {
+            // do nothing
+        } else if (orderEntity.getState() == OrderState.CANCELED) {
             publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);
         } else if (orderEntity.getState() == OrderState.ERRORED) {
             publishOrderCanceledEvent(orderEntity, isStockOccupied, isPaymentCompleted);

--- a/src/main/java/com/project/yogerOrder/order/service/OrderService.java
+++ b/src/main/java/com/project/yogerOrder/order/service/OrderService.java
@@ -88,7 +88,7 @@ public class OrderService {
 
     @Transactional
     public void updateByDeductionFail(Long orderId) {
-        updateByStateChange(findById(orderId), OrderStateChangeEvent.CANCELED);
+        updateByStateChange(findById(orderId), OrderStateChangeEvent.STOCK_DEDUCT_FAILED);
     }
 
     @Transactional
@@ -105,7 +105,7 @@ public class OrderService {
 
     @Transactional
     public void updateByPaymentCanceled(Long orderId) {
-        updateByStateChange(findById(orderId), OrderStateChangeEvent.CANCELED);
+        updateByStateChange(findById(orderId), OrderStateChangeEvent.PAYMENT_CANCELED);
     }
 
     // 주기적 pending 상태 order를 만료 상태로 변경하고 상품 재고 release
@@ -125,7 +125,7 @@ public class OrderService {
 
 
     private void updateByExpiration(OrderEntity orderEntity) {
-        updateByStateChange(orderEntity, OrderStateChangeEvent.CANCELED);
+        updateByStateChange(orderEntity, OrderStateChangeEvent.EXPIRED);
     }
 
     private void updateByStateChange(OrderEntity orderEntity, OrderStateChangeEvent orderStateChangeEvent) {

--- a/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStateChangeEvent.java
+++ b/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStateChangeEvent.java
@@ -1,5 +1,5 @@
 package com.project.yogerOrder.order.util.stateMachine;
 
 public enum OrderStateChangeEvent {
-    STOCK_DEDUCTED, PAID, CANCELED, ERRORED;
+    STOCK_DEDUCTED, STOCK_DEDUCT_FAILED, PAID, PAYMENT_CANCELED, EXPIRED, ERRORED;
 }

--- a/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStaticStateMachine.java
+++ b/src/main/java/com/project/yogerOrder/order/util/stateMachine/OrderStaticStateMachine.java
@@ -15,23 +15,29 @@ public class OrderStaticStateMachine {
     static {
         entryTransition(OrderState.CREATED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.STOCK_CONFIRMED);
         entryTransition(OrderState.CREATED, OrderStateChangeEvent.PAID, OrderState.PAYMENT_COMPLETED);
-        entryTransition(OrderState.CREATED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.CREATED, OrderStateChangeEvent.STOCK_DEDUCT_FAILED, OrderState.CANCELED);
+        entryTransition(OrderState.CREATED, OrderStateChangeEvent.PAYMENT_CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.CREATED, OrderStateChangeEvent.EXPIRED, OrderState.CANCELED);
 
         entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.PAID, OrderState.COMPLETED);
-        entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.STOCK_DEDUCT_FAILED, OrderState.CANCELED);
+        entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.PAYMENT_CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.EXPIRED, OrderState.CANCELED);
         entryTransition(OrderState.STOCK_CONFIRMED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.STOCK_CONFIRMED);
 
         entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.COMPLETED);
-        entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.STOCK_DEDUCT_FAILED, OrderState.CANCELED);
+        entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.PAYMENT_CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.EXPIRED, OrderState.CANCELED);
         entryTransition(OrderState.PAYMENT_COMPLETED, OrderStateChangeEvent.PAID, OrderState.PAYMENT_COMPLETED);
 
         entryTransition(OrderState.COMPLETED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.COMPLETED);
         entryTransition(OrderState.COMPLETED, OrderStateChangeEvent.PAID, OrderState.COMPLETED);
-        entryTransition(OrderState.COMPLETED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.COMPLETED, OrderStateChangeEvent.EXPIRED, OrderState.CANCELED);
 
         entryTransition(OrderState.CANCELED, OrderStateChangeEvent.STOCK_DEDUCTED, OrderState.CANCELED);
         entryTransition(OrderState.CANCELED, OrderStateChangeEvent.PAID, OrderState.CANCELED);
-        entryTransition(OrderState.CANCELED, OrderStateChangeEvent.CANCELED, OrderState.CANCELED);
+        entryTransition(OrderState.CANCELED, OrderStateChangeEvent.EXPIRED, OrderState.CANCELED);
     }
 
     private static void entryTransition(OrderState currentState, OrderStateChangeEvent event, OrderState nextState) {


### PR DESCRIPTION
### 작업 내용

---

- OrderEventProducer의 stockConfirmed와 paymentFailed 대응 로직 추가
- OrderStateChangeEvent의 Canceled를 stock_deduction_failed, payment_canceled, expired로 구체화

<br>

### 관련 이슈

---

- close #22 

### 기타 사항

---

