### PR TITLE
Fix/#24: 주문, 결제 entity 락 미적용 수정

### DIFF
--- a/src/main/java/com/project/yogerOrder/global/util/lock/OptimisticLockRetry.java
+++ b/src/main/java/com/project/yogerOrder/global/util/lock/OptimisticLockRetry.java
@@ -1,0 +1,12 @@
+package com.project.yogerOrder.global.util.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptimisticLockRetry {
+	int maxRetry() default 3;
+}

--- a/src/main/java/com/project/yogerOrder/global/util/lock/OptimisticLockRetryAOP.java
+++ b/src/main/java/com/project/yogerOrder/global/util/lock/OptimisticLockRetryAOP.java
@@ -1,0 +1,38 @@
+package com.project.yogerOrder.global.util.lock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+public class OptimisticLockRetryAOP {
+
+	@Pointcut("@annotation(com.project.yogerOrder.global.util.lock.OptimisticLockRetry)") // 어노테이션이 붙은 메소드 포인트컷
+	public void optimisticLockRetryMethods() {
+	}
+
+	@Around("optimisticLockRetryMethods() && @annotation(optimisticLockRetry)")
+	public Object retry(ProceedingJoinPoint joinPoint, OptimisticLockRetry optimisticLockRetry) throws Throwable {
+		int maxRetries = optimisticLockRetry.maxRetry();
+		int retryCount = 0;
+
+		while (true) {
+			try {
+				return joinPoint.proceed();
+			} catch (OptimisticLockingFailureException e) {
+				retryCount++;
+				if (maxRetries <= retryCount) {
+					log.error("Optimistic lock retry failed after {} attempts", retryCount, e);
+					throw e; // 최대 재시도 횟수 초과 시 예외 발생
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
+++ b/src/main/java/com/project/yogerOrder/order/entity/OrderEntity.java
@@ -1,17 +1,24 @@
 package com.project.yogerOrder.order.entity;
 
+import java.time.LocalDateTime;
+
 import com.project.yogerOrder.global.entity.BaseTimeEntity;
 import com.project.yogerOrder.order.util.stateMachine.OrderStateChangeEvent;
 import com.project.yogerOrder.order.util.stateMachine.OrderStaticStateMachine;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -38,6 +45,8 @@ public class OrderEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private OrderState state;
 
+    @Version
+    private Long version;
 
     private OrderEntity(Long productId, Integer quantity, Long buyerId, OrderState state) {
         this.productId = productId;

--- a/src/main/java/com/project/yogerOrder/order/service/OrderService.java
+++ b/src/main/java/com/project/yogerOrder/order/service/OrderService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -77,6 +78,7 @@ public class OrderService {
 
     // UPDATE
     @OptimisticLockRetry
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void updateByDeductionSuccess(Long orderId) {
         OrderEntity orderEntity = findById(orderId);
 
@@ -89,11 +91,13 @@ public class OrderService {
     }
 
     @OptimisticLockRetry
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void updateByDeductionFail(Long orderId) {
         updateByStateChange(findById(orderId), OrderStateChangeEvent.STOCK_DEDUCT_FAILED);
     }
 
     @OptimisticLockRetry
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void updateByPaymentCompleted(Long orderId) {
         OrderEntity orderEntity = findById(orderId);
 
@@ -106,13 +110,14 @@ public class OrderService {
     }
 
     @OptimisticLockRetry
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void updateByPaymentCanceled(Long orderId) {
         updateByStateChange(findById(orderId), OrderStateChangeEvent.PAYMENT_CANCELED);
     }
 
     // 주기적 pending 상태 order를 만료 상태로 변경하고 상품 재고 release
-    @Transactional
     @Scheduled(cron = "${order.cron.expiration}")
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     @SchedulerLock(name = "orderExpirationSchedule", lockAtMostFor = "PT50S", lockAtLeastFor = "PT40S")
     public void orderExpirationSchedule() {
         OrderState.getPayableStates().forEach(orderState ->

--- a/src/main/java/com/project/yogerOrder/order/service/OrderService.java
+++ b/src/main/java/com/project/yogerOrder/order/service/OrderService.java
@@ -1,5 +1,14 @@
 package com.project.yogerOrder.order.service;
 
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
+import com.project.yogerOrder.global.util.lock.OptimisticLockRetry;
 import com.project.yogerOrder.order.config.OrderConfig;
 import com.project.yogerOrder.order.dto.request.OrderRequestDTO;
 import com.project.yogerOrder.order.dto.request.OrdersCountRequestDTO;
@@ -12,14 +21,9 @@ import com.project.yogerOrder.order.event.producer.OrderEventProducer;
 import com.project.yogerOrder.order.exception.OrderNotFoundException;
 import com.project.yogerOrder.order.repository.OrderRepository;
 import com.project.yogerOrder.order.util.stateMachine.OrderStateChangeEvent;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -34,8 +38,7 @@ public class OrderService {
 
 
     // CREATE
-    // 주문을 생성하는 과정을 먼저 진행하면, 주문이 생성되고, 재고 감소가 실패하기 전에 주문이 결제되면 문제가 생기기 때문에 재고 감소 먼저 진행
-    // + 일반적으로 외부 서비스에 문제가 생기는 경우가 많기 때문에 외부 서비스 호출 먼저
+    @Transactional
     public Long orderProduct(Long userId, Long productId, OrderRequestDTO orderRequestDTO) {
         OrderEntity pendingOrder = OrderEntity.createPendingOrder(productId, orderRequestDTO.quantity(), userId);
         OrderEntity orderEntity = orderRepository.save(pendingOrder);
@@ -47,7 +50,6 @@ public class OrderService {
 
 
     // READ
-    @Transactional(readOnly = true)
     public OrderEntity findById(Long orderId) {
         return orderRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
     }
@@ -74,7 +76,7 @@ public class OrderService {
     }
 
     // UPDATE
-    @Transactional
+    @OptimisticLockRetry
     public void updateByDeductionSuccess(Long orderId) {
         OrderEntity orderEntity = findById(orderId);
 
@@ -86,12 +88,12 @@ public class OrderService {
         updateByStateChange(orderEntity, OrderStateChangeEvent.STOCK_DEDUCTED);
     }
 
-    @Transactional
+    @OptimisticLockRetry
     public void updateByDeductionFail(Long orderId) {
         updateByStateChange(findById(orderId), OrderStateChangeEvent.STOCK_DEDUCT_FAILED);
     }
 
-    @Transactional
+    @OptimisticLockRetry
     public void updateByPaymentCompleted(Long orderId) {
         OrderEntity orderEntity = findById(orderId);
 
@@ -103,7 +105,7 @@ public class OrderService {
         updateByStateChange(orderEntity, OrderStateChangeEvent.PAID);
     }
 
-    @Transactional
+    @OptimisticLockRetry
     public void updateByPaymentCanceled(Long orderId) {
         updateByStateChange(findById(orderId), OrderStateChangeEvent.PAYMENT_CANCELED);
     }

--- a/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
+++ b/src/main/java/com/project/yogerOrder/payment/entity/PaymentEntity.java
@@ -45,6 +45,9 @@ public class PaymentEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PaymentState state;
 
+    @Version
+    private Long version;
+
     private PaymentEntity(String pgPaymentId, Long orderId, Integer amount, Long userId, PaymentState state) {
         this.pgPaymentId = pgPaymentId;
         this.orderId = orderId;

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentService.java
@@ -1,21 +1,21 @@
 package com.project.yogerOrder.payment.service;
 
+import org.springframework.stereotype.Service;
+
+import com.project.yogerOrder.global.util.lock.OptimisticLockRetry;
 import com.project.yogerOrder.order.entity.OrderEntity;
 import com.project.yogerOrder.order.service.OrderService;
 import com.project.yogerOrder.payment.dto.request.ConfirmPaymentRequestDTO;
 import com.project.yogerOrder.payment.dto.request.VerifyPaymentRequestDTO;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
-import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
 import com.project.yogerOrder.payment.util.pg.dto.request.PGRefundRequestDTO;
 import com.project.yogerOrder.payment.util.pg.dto.resposne.PGPaymentInformResponseDTO;
 import com.project.yogerOrder.payment.util.pg.service.PGClientService;
-import com.project.yogerOrder.payment.util.stateMachine.PaymentStateChangeEvent;
 import com.project.yogerOrder.product.service.ProductService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -32,12 +32,11 @@ public class PaymentService {
 
     private final ProductService productService;
 
-    private final PaymentEventProducer paymentEventProducer;
-
 
     // 웹훅인 줄 알았는데 외부 요청이었으면 -> 상관 없게 로직 작성
     // 신뢰 정보(= 사용자 조작 불가, 검증 필요): 결제 id(존재 검증), 결제 금액(원래 값과 비교), 결제 상태(paid 상태인지 검사)
     // 비신뢰 정보(= 사용자 조작 가능, 검증 필요): 주문 id(다른 주문 결제 검증 필요 X)
+    @OptimisticLockRetry
     public void verifyPayment(VerifyPaymentRequestDTO verifyPaymentRequestDTO) {
         // 결제 id 존재 검증
         if (paymentRepository.existsByPgPaymentId(verifyPaymentRequestDTO.impUid())) { // 내부
@@ -50,7 +49,7 @@ public class PaymentService {
         if (!pgInform.isPaid()) { // 결제된 상태가 아니면 환불 X
             log.error("PG payment {} is not paid state", pgInform.pgPaymentId());
             PaymentEntity errorPayment = cancelPaymentByError(orderEntity, pgInform);
-            saveCanceledPayment(errorPayment, pgInform, false);
+            paymentTransactionService.saveCanceledPayment(errorPayment);
 
             return;
         }
@@ -59,7 +58,8 @@ public class PaymentService {
         if (!orderService.isPayable(orderEntity)) { // 내부
             log.debug("payment {} is not payable", pgInform.pgPaymentId());
             PaymentEntity canceledPayment = cancelPaymentByValidation(orderEntity, pgInform);
-            saveCanceledPayment(canceledPayment, pgInform, true);
+            pgClientService.refund(new PGRefundRequestDTO(pgInform.pgPaymentId(), pgInform.amount()));
+            paymentTransactionService.saveCanceledPayment(canceledPayment);
 
             return;
         }
@@ -68,7 +68,8 @@ public class PaymentService {
         if (pgInform.amount() != (originalMaxPrice * orderEntity.getQuantity())) { // 내부
             log.error("PG payment {} is invalid", pgInform.pgPaymentId());
             PaymentEntity errorPayment = cancelPaymentByError(orderEntity, pgInform);
-            saveCanceledPayment(errorPayment, pgInform, true);
+            pgClientService.refund(new PGRefundRequestDTO(pgInform.pgPaymentId(), pgInform.amount()));
+            paymentTransactionService.saveCanceledPayment(errorPayment);
 
             return;
         }
@@ -99,28 +100,8 @@ public class PaymentService {
         );
     }
 
-    private void saveCanceledPayment(PaymentEntity paymentEntity, PGPaymentInformResponseDTO pgInform,
-                                     Boolean isRefund) {
-        paymentRepository.save(paymentEntity);
-
-        if (isRefund) pgClientService.refund(new PGRefundRequestDTO(pgInform.pgPaymentId(), pgInform.amount()));
-
-        paymentEventProducer.publishEventByState(paymentEntity);
-    }
-
-    @Transactional
+    @OptimisticLockRetry
     public void orderCanceled(Long orderId) {
-        paymentRepository.findByOrderId(orderId).ifPresent(paymentEntity -> {
-            Boolean isUpdated = paymentEntity.changeStateIfChangeable(PaymentStateChangeEvent.ORDER_CANCELED);
-            if (!isUpdated) {
-                log.debug("payment {} is already canceled", paymentEntity.getId());
-                return;
-            }
-            paymentRepository.save(paymentEntity);
-
-            pgClientService.refund(new PGRefundRequestDTO(paymentEntity.getPgPaymentId(), paymentEntity.getAmount()));
-
-            paymentEventProducer.publishEventByState(paymentEntity);
-        });
+        paymentTransactionService.orderCanceled(orderId);
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
@@ -1,24 +1,33 @@
 package com.project.yogerOrder.payment.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.project.yogerOrder.payment.dto.request.ConfirmPaymentRequestDTO;
 import com.project.yogerOrder.payment.entity.PaymentEntity;
 import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.project.yogerOrder.payment.util.pg.dto.request.PGRefundRequestDTO;
+import com.project.yogerOrder.payment.util.pg.service.PGClientService;
+import com.project.yogerOrder.payment.util.stateMachine.PaymentStateChangeEvent;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class PaymentTransactionService {
+class PaymentTransactionService {
 
     private final PaymentRepository paymentRepository;
+
+    private final PGClientService pgClientService;
 
     private final PaymentEventProducer paymentEventProducer;
 
     @Transactional
-    public void confirmPayment(ConfirmPaymentRequestDTO confirmPaymentRequestDTO) {
+    void confirmPayment(ConfirmPaymentRequestDTO confirmPaymentRequestDTO) {
         PaymentEntity paymentEntity = PaymentEntity.createPaidPayment(
                 confirmPaymentRequestDTO.pgPaymentId(),
                 confirmPaymentRequestDTO.orderId(),
@@ -28,5 +37,28 @@ public class PaymentTransactionService {
         paymentRepository.save(paymentEntity);
 
         paymentEventProducer.publishEventByState(paymentEntity);
+    }
+
+    @Transactional
+    void saveCanceledPayment(PaymentEntity paymentEntity) {
+        paymentRepository.save(paymentEntity);
+
+        paymentEventProducer.publishEventByState(paymentEntity);
+    }
+
+    @Transactional
+    void orderCanceled(Long orderId) {
+        paymentRepository.findByOrderId(orderId).ifPresent(paymentEntity -> {
+            Boolean isUpdated = paymentEntity.changeStateIfChangeable(PaymentStateChangeEvent.ORDER_CANCELED);
+            if (!isUpdated) {
+                log.debug("payment {} is already canceled", paymentEntity.getId());
+                return;
+            }
+            pgClientService.refund(new PGRefundRequestDTO(paymentEntity.getPgPaymentId(), paymentEntity.getAmount()));
+
+            paymentRepository.save(paymentEntity);
+
+            paymentEventProducer.publishEventByState(paymentEntity);
+        });
     }
 }

--- a/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/project/yogerOrder/payment/service/PaymentTransactionService.java
@@ -1,6 +1,7 @@
 package com.project.yogerOrder.payment.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.project.yogerOrder.payment.dto.request.ConfirmPaymentRequestDTO;
@@ -39,14 +40,14 @@ class PaymentTransactionService {
         paymentEventProducer.publishEventByState(paymentEntity);
     }
 
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     void saveCanceledPayment(PaymentEntity paymentEntity) {
         paymentRepository.save(paymentEntity);
 
         paymentEventProducer.publishEventByState(paymentEntity);
     }
 
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     void orderCanceled(Long orderId) {
         paymentRepository.findByOrderId(orderId).ifPresent(paymentEntity -> {
             Boolean isUpdated = paymentEntity.changeStateIfChangeable(PaymentStateChangeEvent.ORDER_CANCELED);

--- a/src/test/java/com/project/yogerOrder/YogerOrderApplicationTests.java
+++ b/src/test/java/com/project/yogerOrder/YogerOrderApplicationTests.java
@@ -1,13 +1,7 @@
 package com.project.yogerOrder;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class YogerOrderApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
 }

--- a/src/test/java/com/project/yogerOrder/global/UsingTestContainerTest.java
+++ b/src/test/java/com/project/yogerOrder/global/UsingTestContainerTest.java
@@ -1,47 +1,37 @@
 package com.project.yogerOrder.global;
 
-import com.project.yogerOrder.global.support.DBInitializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
+
+import com.project.yogerOrder.global.support.DBInitializer;
 
 @Testcontainers
 @ActiveProfiles("test")
 @Import({DBInitializer.class, KafkaTestConfig.class})
 public abstract class UsingTestContainerTest {
-    private static final String DB_USERNAME = "root";
-    private static final String DB_PASSWORD = "1234";
 
     @Autowired
     private DBInitializer dbInitializer;
 
     @Container
-    static final MySQLContainer MYSQL_CONTAINER = (MySQLContainer) new MySQLContainer("mysql:latest")
-            .withDatabaseName("test")
-            .withUsername(DB_USERNAME)
-            .withPassword(DB_PASSWORD)
+    @ServiceConnection
+    static final MySQLContainer MYSQL_CONTAINER = (MySQLContainer) new MySQLContainer("mysql:8.0.41")
             .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci");
 
     @Container
     static final KafkaContainer KAFKA_CONTAINER = new KafkaContainer(
-            DockerImageName.parse("confluentinc/cp-kafka:5.4.3")
+            DockerImageName.parse("apache/kafka:3.8.0")
     );
-
-
-    @DynamicPropertySource
-    private static void dynamicPropertySource(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
-        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
-        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
-    }
 
     @DynamicPropertySource
     private static void kafkaContainerProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/project/yogerOrder/order/OrderIntegrationTest.java
+++ b/src/test/java/com/project/yogerOrder/order/OrderIntegrationTest.java
@@ -1,5 +1,22 @@
 package com.project.yogerOrder.order;
 
+import static org.awaitility.Awaitility.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.project.yogerOrder.global.UsingTestContainerTest;
 import com.project.yogerOrder.order.entity.OrderEntity;
@@ -13,21 +30,8 @@ import com.project.yogerOrder.product.config.ProductTopic;
 import com.project.yogerOrder.product.event.ProductDeductionCompletedEvent;
 import com.project.yogerOrder.product.event.ProductDeductionFailedEvent;
 import com.project.yogerOrder.product.event.ProductEventType;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.stream.Stream;
-
-import static org.awaitility.Awaitility.await;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import jakarta.persistence.EntityManager;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 public class OrderIntegrationTest extends UsingTestContainerTest {
@@ -37,6 +41,12 @@ public class OrderIntegrationTest extends UsingTestContainerTest {
 
     @Autowired
     OrderRepository orderRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    TransactionTemplate transactionTemplate;
 
     private static final Long productId = 1L;
     private static final Integer quantity = 2;
@@ -53,8 +63,12 @@ public class OrderIntegrationTest extends UsingTestContainerTest {
         OrderEntity initialOrder = OrderEntity.createPendingOrder(productId, quantity, userId);
         ReflectionTestUtils.setField(initialOrder, "id", orderId);
         ReflectionTestUtils.setField(initialOrder, "state", startState);
+        ReflectionTestUtils.setField(initialOrder, "version", 1L);
 
-        orderRepository.save(initialOrder);
+        // ReflectionTestUtils.setField()로 설정하면 jpa entity가 detach됨. 이것을 해결하기 위해 영속 상태로 만들어야 함.
+        OrderEntity mergedInitialOrder = transactionTemplate.execute(status -> entityManager.merge(initialOrder));
+
+        orderRepository.save(Objects.requireNonNull(mergedInitialOrder));
 
         // when
         kafkaTemplate.executeInTransaction(kafkaTemplate -> {

--- a/src/test/java/com/project/yogerOrder/order/service/OrderServiceTest.java
+++ b/src/test/java/com/project/yogerOrder/order/service/OrderServiceTest.java
@@ -1,11 +1,8 @@
 package com.project.yogerOrder.order.service;
 
-import com.project.yogerOrder.order.config.OrderConfig;
-import com.project.yogerOrder.order.dto.request.OrderRequestDTO;
-import com.project.yogerOrder.order.entity.OrderEntity;
-import com.project.yogerOrder.order.entity.OrderState;
-import com.project.yogerOrder.order.event.producer.OrderEventProducer;
-import com.project.yogerOrder.order.repository.OrderRepository;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +17,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDateTime;
-import java.util.stream.Stream;
+import com.project.yogerOrder.order.config.OrderConfig;
+import com.project.yogerOrder.order.dto.request.OrderRequestDTO;
+import com.project.yogerOrder.order.entity.OrderEntity;
+import com.project.yogerOrder.order.entity.OrderState;
+import com.project.yogerOrder.order.event.producer.OrderEventProducer;
+import com.project.yogerOrder.order.repository.OrderRepository;
 
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(OrderConfig.class)
@@ -69,7 +70,7 @@ class OrderServiceTest {
     @MethodSource("isPayableSource")
     void isPayable(OrderState ordersState, Integer pastMinutes, Boolean expectedPayable) {
         // given
-        OrderEntity order = new OrderEntity(1L, 1L, 1, 1L, ordersState);
+        OrderEntity order = new OrderEntity(1L, 1L, 1, 1L, ordersState, 1L);
         ReflectionTestUtils.setField(order, "createdTime", LocalDateTime.now().minusMinutes(pastMinutes));
 
         // when

--- a/src/test/java/com/project/yogerOrder/payment/PaymentIntegrationTest.java
+++ b/src/test/java/com/project/yogerOrder/payment/PaymentIntegrationTest.java
@@ -1,5 +1,17 @@
 package com.project.yogerOrder.payment;
 
+import static org.awaitility.Awaitility.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.*;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.project.yogerOrder.global.UsingTestContainerTest;
 import com.project.yogerOrder.order.config.OrderTopic;
@@ -10,18 +22,6 @@ import com.project.yogerOrder.payment.entity.PaymentState;
 import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
 import com.project.yogerOrder.payment.repository.PaymentRepository;
 import com.project.yogerOrder.payment.util.pg.service.PGClientService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.time.Duration;
-
-import static org.awaitility.Awaitility.await;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 public class PaymentIntegrationTest extends UsingTestContainerTest {
@@ -42,7 +42,6 @@ public class PaymentIntegrationTest extends UsingTestContainerTest {
     @Test
     void paymentStateChangeTest() {
         // given
-        Long paymentId = 1L;
         String impUid = "imp_123123123";
         Long orderId = 123123L;
         Integer amount = 1000;
@@ -54,8 +53,7 @@ public class PaymentIntegrationTest extends UsingTestContainerTest {
 
         // payment entity 생성 후 저장
         PaymentEntity tempPaidPayment = PaymentEntity.createPaidPayment(impUid, orderId, amount, userId);
-        ReflectionTestUtils.setField(tempPaidPayment, "id", paymentId); // id 설정
-        paymentRepository.save(tempPaidPayment);
+        Long paymentId = paymentRepository.save(tempPaidPayment).getId();
 
         // orderCanceledEvent 생성을 위한 order entity 생성 후 활용
         OrderEntity orderEntity = OrderEntity.createPendingOrder(productId, quantity, userId);

--- a/src/test/java/com/project/yogerOrder/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/project/yogerOrder/payment/service/PaymentServiceTest.java
@@ -1,20 +1,13 @@
 package com.project.yogerOrder.payment.service;
 
-import com.project.yogerOrder.order.entity.OrderEntity;
-import com.project.yogerOrder.order.service.OrderService;
-import com.project.yogerOrder.payment.dto.request.ConfirmPaymentRequestDTO;
-import com.project.yogerOrder.payment.dto.request.VerifyPaymentRequestDTO;
-import com.project.yogerOrder.payment.dto.response.PaymentOrderDTO;
-import com.project.yogerOrder.payment.entity.PaymentEntity;
-import com.project.yogerOrder.payment.event.producer.PaymentEventProducer;
-import com.project.yogerOrder.payment.repository.PaymentRepository;
-import com.project.yogerOrder.payment.util.pg.dto.request.PGRefundRequestDTO;
-import com.project.yogerOrder.payment.util.pg.dto.resposne.PGPaymentInformResponseDTO;
-import com.project.yogerOrder.payment.util.pg.enums.PGState;
-import com.project.yogerOrder.payment.util.pg.service.PGClientService;
-import com.project.yogerOrder.product.dto.response.PriceByQuantity;
-import com.project.yogerOrder.product.dto.response.ProductResponseDTO;
-import com.project.yogerOrder.product.service.ProductService;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,14 +21,20 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import com.project.yogerOrder.order.entity.OrderEntity;
+import com.project.yogerOrder.order.service.OrderService;
+import com.project.yogerOrder.payment.dto.request.ConfirmPaymentRequestDTO;
+import com.project.yogerOrder.payment.dto.request.VerifyPaymentRequestDTO;
+import com.project.yogerOrder.payment.dto.response.PaymentOrderDTO;
+import com.project.yogerOrder.payment.entity.PaymentEntity;
+import com.project.yogerOrder.payment.repository.PaymentRepository;
+import com.project.yogerOrder.payment.util.pg.dto.request.PGRefundRequestDTO;
+import com.project.yogerOrder.payment.util.pg.dto.resposne.PGPaymentInformResponseDTO;
+import com.project.yogerOrder.payment.util.pg.enums.PGState;
+import com.project.yogerOrder.payment.util.pg.service.PGClientService;
+import com.project.yogerOrder.product.dto.response.PriceByQuantity;
+import com.project.yogerOrder.product.dto.response.ProductResponseDTO;
+import com.project.yogerOrder.product.service.ProductService;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentServiceTest {
@@ -57,9 +56,6 @@ class PaymentServiceTest {
 
     @Mock
     private ProductService productService;
-
-    @Mock
-    private PaymentEventProducer paymentEventProducer;
 
     private TestSource source1;
 
@@ -186,7 +182,7 @@ class PaymentServiceTest {
     @Test
     void verifyFailByAmount() {
         // given
-        ArgumentCaptor<PGRefundRequestDTO> captor = ArgumentCaptor.forClass(PGRefundRequestDTO.class);
+        ArgumentCaptor<PaymentEntity> captor = ArgumentCaptor.forClass(PaymentEntity.class);
 
         PGPaymentInformResponseDTO invalidPGInform = new PGPaymentInformResponseDTO(
                 source1.impUid, source1.merchantUid, (int) (source1.pgInform.amount() * 0.1), PGState.PAID
@@ -201,11 +197,10 @@ class PaymentServiceTest {
         // when
         paymentService.verifyPayment(source1.requestDTO);
 
-        // when, then
-        verify(pgClientService, times(1)).refund(captor.capture());
-        Assertions.assertThat(captor.getValue().paymentId()).isEqualTo(source1.pgInform.pgPaymentId());
-        Assertions.assertThat(captor.getValue().checksum()).isEqualTo(invalidPGInform.amount());
-        Assertions.assertThat(captor.getValue().refundAmount()).isEqualTo(invalidPGInform.amount());
+        // then
+        verify(paymentTransactionService, times(1)).saveCanceledPayment(captor.capture());
+        Assertions.assertThat(captor.getValue().getPgPaymentId()).isEqualTo(source1.pgInform.pgPaymentId());
+        Assertions.assertThat(captor.getValue().getAmount()).isEqualTo(invalidPGInform.amount());
         verify(paymentTransactionService, times(0)).confirmPayment(any(ConfirmPaymentRequestDTO.class));
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,6 @@ spring:
         password: ${DB_PASSWORD}
 
     jpa:
-        #show-sql: true
         hibernate:
             ddl-auto: create
         properties:
@@ -20,7 +19,7 @@ spring:
         virtual:
             enabled: true
 
-portOne:
+port-one:
     v1:
         APIKey: ${V1_APIKEY}
         APISecret: ${V1_APISECRET}
@@ -42,24 +41,11 @@ logging:
     level:
         org.library.yogerLibrary.log: DEBUG
 
-management:
-    endpoints:
-        web:
-            exposure:
-                include: "*"
-    metrics:
-        enable:
-            jvm: true
-
 kafka:
-    admin:
-        bootstrap-servers: "localhost:9092"
     producer:
-        bootstrap-servers: "localhost:9092"
         enable-idempotence: true
         transaction-id-prefix: tx-
     consumer:
-        bootstrap-servers: "localhost:9092"
         auto-offset-reset: earliest
         enable-auto-commit: false
         isolation-level: read_committed


### PR DESCRIPTION
### 작업 내용

---

- 주문 및 결제 entity에 낙관적 락 적용
- 낙관적 락 적용에 따른, 최신 state를 기반으로 state transition을 진행하기 위한, transaction isolation 수준 read_committed로 하향 조정

<br>

### 관련 이슈

---

- close #24 

### 기타 사항

---

