### PR TITLE
Refactor/#55: cache stampede 방지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	runtimeOnly 'com.mysql:mysql-connector-j:9.+'
 

--- a/src/main/java/com/project/yogerOrder/global/config/RedisConfig.java
+++ b/src/main/java/com/project/yogerOrder/global/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.project.yogerOrder.global.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +13,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+	
+	private static final String REDIS_URL_PREFIX = "redis://";
 
 	@Bean
 	public LettuceConnectionFactory lettuceConnectionFactory(RedisProperties properties) {
@@ -29,5 +34,15 @@ public class RedisConfig {
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
 		return redisTemplate;
+	}
+
+	@Bean
+	public RedissonClient redissonClient(RedisProperties properties) {
+		Config config = new Config();
+		config.useSingleServer() // 임시로 단일 서버 설정
+			.setAddress(REDIS_URL_PREFIX + properties.getHost() + ":" + properties.getPort())
+			.setPassword(properties.getPassword());
+		
+		return Redisson.create(config);
 	}
 }

--- a/src/main/java/com/project/yogerOrder/global/util/lock/multi/DistributedMultiLockHandler.java
+++ b/src/main/java/com/project/yogerOrder/global/util/lock/multi/DistributedMultiLockHandler.java
@@ -1,0 +1,49 @@
+package com.project.yogerOrder.global.util.lock.multi;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DistributedMultiLockHandler {
+	
+	private final RedissonClient redissonClient;
+	
+	
+	public <T> T handleWithLock(List<String> keys, long waitTimeInMilliSeconds, long leaseTimeInMilliSeconds, Supplier<T> logic) {
+		// 변경 가능한 리스트로 복사
+		keys = new ArrayList<>(keys);
+		// 데드락 방지를 위해 키를 정렬
+		Collections.sort(keys);
+		
+		RLock[] rLocks = keys.stream()
+			.map(redissonClient::getLock)
+			.toArray(RLock[]::new);
+		
+		RLock multiLock = redissonClient.getMultiLock(rLocks);
+		
+		try {
+			if (multiLock.tryLock(waitTimeInMilliSeconds, leaseTimeInMilliSeconds, TimeUnit.MILLISECONDS)) {
+				return logic.get();
+			} else {
+				throw new IllegalMonitorStateException("Failed to acquire multi lock within wait time for keys: " + keys);
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Lock acquisition was interrupted.", e);
+		} finally {
+			if (multiLock.isHeldByCurrentThread()) {
+				multiLock.unlock();
+			}
+		}
+	}
+}

--- a/src/main/java/com/project/yogerOrder/product/cache/domain/entity/ProductCacheEntity.java
+++ b/src/main/java/com/project/yogerOrder/product/cache/domain/entity/ProductCacheEntity.java
@@ -1,4 +1,4 @@
-package com.project.yogerOrder.product.cache.entity;
+package com.project.yogerOrder.product.cache.domain.entity;
 
 import com.project.yogerOrder.product.entity.ProductEntity;
 import jakarta.persistence.Id;

--- a/src/main/java/com/project/yogerOrder/product/cache/domain/repository/ProductCacheRepository.java
+++ b/src/main/java/com/project/yogerOrder/product/cache/domain/repository/ProductCacheRepository.java
@@ -1,7 +1,7 @@
-package com.project.yogerOrder.product.cache.repository;
+package com.project.yogerOrder.product.cache.domain.repository;
 
 import com.project.yogerOrder.global.util.db.ExcludeFromJpaRepository;
-import com.project.yogerOrder.product.cache.entity.ProductCacheEntity;
+import com.project.yogerOrder.product.cache.domain.entity.ProductCacheEntity;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/project/yogerOrder/product/cache/domain/service/ProductCacheService.java
+++ b/src/main/java/com/project/yogerOrder/product/cache/domain/service/ProductCacheService.java
@@ -1,7 +1,7 @@
-package com.project.yogerOrder.product.cache.service;
+package com.project.yogerOrder.product.cache.domain.service;
 
-import com.project.yogerOrder.product.cache.entity.ProductCacheEntity;
-import com.project.yogerOrder.product.cache.repository.ProductCacheRepository;
+import com.project.yogerOrder.product.cache.domain.entity.ProductCacheEntity;
+import com.project.yogerOrder.product.cache.domain.repository.ProductCacheRepository;
 import com.project.yogerOrder.product.entity.ProductEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/project/yogerOrder/product/cache/lock/service/ProductLockService.java
+++ b/src/main/java/com/project/yogerOrder/product/cache/lock/service/ProductLockService.java
@@ -1,0 +1,37 @@
+package com.project.yogerOrder.product.cache.lock.service;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.springframework.stereotype.Service;
+
+import com.project.yogerOrder.global.util.lock.multi.DistributedMultiLockHandler;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductLockService {
+	
+	private static final String PRODUCT_LOCK_KEY_PREFIX = "product_lock:";
+	
+	private static final Long DEFAULT_WAIT_TIME_MILLIS = 5000L;
+	
+	private static final Long DEFAULT_LEASE_TIME_MILLIS = 10000L;
+	
+	
+	private final DistributedMultiLockHandler distributedMultiLockHandler;
+	
+	public <T> T runWithDistributedLock(List<Long> productIds, Supplier<T> logic) {
+		List<String> lockKeys = productIds.stream()
+			.map(id -> PRODUCT_LOCK_KEY_PREFIX + id)
+			.toList();
+		
+		return distributedMultiLockHandler.handleWithLock(
+			lockKeys,
+			DEFAULT_WAIT_TIME_MILLIS,
+			DEFAULT_LEASE_TIME_MILLIS,
+			logic
+		);
+	}
+}

--- a/src/main/java/com/project/yogerOrder/product/dto/response/ProductResponseDTO.java
+++ b/src/main/java/com/project/yogerOrder/product/dto/response/ProductResponseDTO.java
@@ -1,7 +1,7 @@
 package com.project.yogerOrder.product.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.project.yogerOrder.product.cache.entity.ProductCacheEntity;
+import com.project.yogerOrder.product.cache.domain.entity.ProductCacheEntity;
 import com.project.yogerOrder.product.entity.ProductEntity;
 
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/project/yogerOrder/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/project/yogerOrder/product/service/ProductServiceImpl.java
@@ -1,8 +1,8 @@
 package com.project.yogerOrder.product.service;
 
 import com.project.yogerOrder.order.entity.OrderItem;
-import com.project.yogerOrder.product.cache.entity.ProductCacheEntity;
-import com.project.yogerOrder.product.cache.service.ProductCacheService;
+import com.project.yogerOrder.product.cache.domain.entity.ProductCacheEntity;
+import com.project.yogerOrder.product.cache.domain.service.ProductCacheService;
 import com.project.yogerOrder.product.config.ProductConfig;
 import com.project.yogerOrder.product.dto.request.ReserveProductsRequestDTO;
 import com.project.yogerOrder.product.dto.request.UpsertProductRequestDTO;

--- a/src/main/java/com/project/yogerOrder/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/project/yogerOrder/product/service/ProductServiceImpl.java
@@ -1,8 +1,21 @@
 package com.project.yogerOrder.product.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
 import com.project.yogerOrder.order.entity.OrderItem;
 import com.project.yogerOrder.product.cache.domain.entity.ProductCacheEntity;
 import com.project.yogerOrder.product.cache.domain.service.ProductCacheService;
+import com.project.yogerOrder.product.cache.lock.service.ProductLockService;
 import com.project.yogerOrder.product.config.ProductConfig;
 import com.project.yogerOrder.product.dto.request.ReserveProductsRequestDTO;
 import com.project.yogerOrder.product.dto.request.UpsertProductRequestDTO;
@@ -14,19 +27,8 @@ import com.project.yogerOrder.product.exception.ProductServerStateException;
 import com.project.yogerOrder.product.exception.handler.ProductClientErrorHandler;
 import com.project.yogerOrder.product.exception.handler.ProductServerErrorHandler;
 import com.project.yogerOrder.product.repository.ProductRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClient;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -38,13 +40,16 @@ public class ProductServiceImpl implements ProductService {
 
 	private final ProductCacheService productCacheService;
 	
+	private final ProductLockService productLockService;
+	
 	@Autowired
 	public ProductServiceImpl(ProductRepository productRepository,
 		ProductConfig config,
 		RestClient.Builder restClientBuilder, // 테스트하기 위해서 builder를 주입받아야 함
 		ProductClientErrorHandler productClientErrorHandler,
 		ProductServerErrorHandler productServerErrorHandler,
-	    ProductCacheService productCacheService) {
+	    ProductCacheService productCacheService,
+		ProductLockService productLockService) {
 		
 		this.productRepository = productRepository;
 		this.restClient = restClientBuilder
@@ -54,6 +59,7 @@ public class ProductServiceImpl implements ProductService {
 			.defaultStatusHandler(HttpStatusCode::is5xxServerError, productServerErrorHandler)
 			.build();
 		this.productCacheService = productCacheService;
+		this.productLockService = productLockService;
 	}
 	
 	
@@ -74,19 +80,50 @@ public class ProductServiceImpl implements ProductService {
 
 	@Override
 	public List<ProductResponseDTO> findByIds(List<Long> productIds) throws ProductNotFoundException {
+		// 최초 캐시 조회
 		List<ProductCacheEntity> productCaches = productCacheService.findAllByIds(productIds);
-		ArrayList<ProductResponseDTO> productResponseDTOs = new ArrayList<>(productCaches.stream().map(ProductResponseDTO::from).toList());
+		List<ProductResponseDTO> productResponseDTOs = productCaches.stream()
+			.map(ProductResponseDTO::from)
+			.collect(Collectors.toList()); // 수정가능하도록 반환
 
+		// 캐시에 없는 상품 키 필터링
 		List<Long> productKeysInDB = findKeysInDB(productIds, productCaches);
+		
+		// 캐시에 없는 상품이 있는 경우 잠금 획득 후 갱신 처리
 		if (!productKeysInDB.isEmpty()) {
-			List<ProductEntity> productEntities = productRepository.findAllById(productKeysInDB);
-			if (productEntities.size() != productKeysInDB.size()) {
-				throw new ProductNotFoundException();
-			}
-
-			productResponseDTOs.addAll(productEntities.stream().map(ProductResponseDTO::from).toList());
-
-			productCacheService.saveAll(productEntities);
+			List<ProductResponseDTO> refreshedProductResponseDTOs = productLockService.runWithDistributedLock(
+				productKeysInDB,
+				() -> {
+					// Lock 획득 후 다시 캐시 확인
+					List<ProductCacheEntity> refreshedProductCaches = productCacheService.findAllByIds(productKeysInDB);
+					List<Long> refreshedKeysInDB = findKeysInDB(productKeysInDB, refreshedProductCaches);
+					
+					List<ProductResponseDTO> productResponseDTOs2 = refreshedProductCaches.stream()
+						.map(ProductResponseDTO::from)
+						.collect(Collectors.toList());
+					
+					// 캐시에 모두 존재하지 않는 경우
+					if (!refreshedKeysInDB.isEmpty()) {
+						// DB 조회
+						List<ProductEntity> productEntities = productRepository.findAllById(refreshedKeysInDB);
+						if (productEntities.size() != refreshedKeysInDB.size()) {
+							throw new ProductNotFoundException();
+						}
+						
+						// 캐시 저장
+						productCacheService.saveAll(productEntities);
+						
+						productResponseDTOs2.addAll(productEntities.stream()
+							.map(ProductResponseDTO::from)
+							.toList()
+						);
+					}
+					
+					return productResponseDTOs2;
+				}
+			);
+			
+			productResponseDTOs.addAll(refreshedProductResponseDTOs);
 		}
 
 		return productResponseDTOs;

--- a/src/test/java/com/project/yogerOrder/product/ProductExternalTest.java
+++ b/src/test/java/com/project/yogerOrder/product/ProductExternalTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.yogerOrder.global.exception.ErrorResponse;
 import com.project.yogerOrder.order.entity.OrderItem;
 import com.project.yogerOrder.product.cache.domain.service.ProductCacheService;
+import com.project.yogerOrder.product.cache.lock.service.ProductLockService;
 import com.project.yogerOrder.product.config.ProductConfig;
 import com.project.yogerOrder.product.exception.ProductInsufficientException;
 import com.project.yogerOrder.product.exception.handler.ProductClientErrorHandler;
@@ -50,6 +51,10 @@ public class ProductExternalTest {
 	
 	@MockitoBean
 	private ProductCacheService productCacheService;
+	
+	@MockitoBean
+	private ProductLockService productLockService;
+	
 	
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	

--- a/src/test/java/com/project/yogerOrder/product/ProductExternalTest.java
+++ b/src/test/java/com/project/yogerOrder/product/ProductExternalTest.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.yogerOrder.global.exception.ErrorResponse;
 import com.project.yogerOrder.order.entity.OrderItem;
-import com.project.yogerOrder.product.cache.service.ProductCacheService;
+import com.project.yogerOrder.product.cache.domain.service.ProductCacheService;
 import com.project.yogerOrder.product.config.ProductConfig;
 import com.project.yogerOrder.product.exception.ProductInsufficientException;
 import com.project.yogerOrder.product.exception.handler.ProductClientErrorHandler;

--- a/src/test/java/com/project/yogerOrder/product/cache/ProductCacheTest.java
+++ b/src/test/java/com/project/yogerOrder/product/cache/ProductCacheTest.java
@@ -1,8 +1,8 @@
 package com.project.yogerOrder.product.cache;
 
 import com.project.yogerOrder.global.UsingTestContainerTest;
-import com.project.yogerOrder.product.cache.entity.ProductCacheEntity;
-import com.project.yogerOrder.product.cache.service.ProductCacheService;
+import com.project.yogerOrder.product.cache.domain.entity.ProductCacheEntity;
+import com.project.yogerOrder.product.cache.domain.service.ProductCacheService;
 import com.project.yogerOrder.product.entity.ProductEntity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### 작업 내용

---

<!-- 작업 내용 -->

<기존 상황>
<img width="787" height="303" alt="image" src="https://github.com/user-attachments/assets/121fd497-d422-4817-a5d6-712c01180fd7" />

기존에 product 정보 cache가 ttl이 만료되면, DB에서 정보를 갱신해 오는 로직이 존재하였습니다.
이 로직에서 cache stampede 현상이 발생하는 걸 확인하였습니다.
이 로직에 Redisson 분산 락을 적용해서 DB에 접근하는 스레드가 하나만 존재하도록 refactoring하였습니다.


<개편 후 상황>
<img width="798" height="693" alt="image" src="https://github.com/user-attachments/assets/0ef053e5-6b13-447d-bffc-7a95c18717e1" />

캐시를 수동으로 만료시키는 상황에도, DB에 접근하는 스레드가 폭주하지 않는 상황을 관측했습니다.


<개편 후 잔류 문제>
<img width="1579" height="425" alt="image" src="https://github.com/user-attachments/assets/d7fe21bc-5bbe-47a1-9c63-18252b12a335" />

그러나 캐시를 갱신할 때마다 latency가 급등하는 문제가 있습니다. 이것을 해결하기 위해서 Two Level TTL을 적용할 수 있습니다. 이 부분은 차후 PR을 통해 갱신할 예정입니다.




<br>

### 관련 이슈

---

- close #55 

### 기타 사항

---

